### PR TITLE
Fixes the gamemode being confused after a RTV and other issues.

### DIFF
--- a/addons/sourcemod/scripting/modules/events.sp
+++ b/addons/sourcemod/scripting/modules/events.sp
@@ -144,7 +144,7 @@ public Action RoundStart(Event event, const char[] name, bool dontBroadcast)
 
 	int playing;
 	for( int iplay=MaxClients ; iplay ; --iplay ) {
-		if( !IsValidClient(iplay) )	
+		if( !IsClientInGame(iplay) )
 			continue;
 
 		ManageResetVariables(BaseBoss(iplay));	// in handler.sp
@@ -163,11 +163,13 @@ public Action RoundStart(Event event, const char[] name, bool dontBroadcast)
 		gamemode.iRoundState = StateDisabled;
 		SetArenaCapEnableTime(60.0);
 		SetConVarInt(FindConVar("mp_teams_unbalance_limit"), 1);
+		SetConVarInt(FindConVar("mp_forceautoteam"), 1);
 		SetPawnTimer(EnableCap, 71.0); //CreateTimer(71.0, Timer_EnableCap, _, TIMER_FLAG_NO_MAPCHANGE);
 		return Plugin_Continue;
 	}
 	
 	SetConVarInt(FindConVar("mp_teams_unbalance_limit"), 0);
+	SetConVarInt(FindConVar("mp_forceautoteam"), 0);
 
 	BaseBoss boss = gamemode.FindNextBoss();
 	if( boss.index <= 0 ) {
@@ -343,7 +345,7 @@ public Action ItemPickedUp(Event event, const char[] name, bool dontBroadcast)
 
 public Action UberDeployed(Event event, const char[] name, bool dontBroadcast)
 {
-	if( !bEnabled.BoolValue )
+	if( !bEnabled.BoolValue or gamemode.iRoundState == StateDisabled)
 		return Plugin_Continue;
 	
 	BaseBoss medic = BaseBoss(event.GetInt("userid"), true);
@@ -371,7 +373,7 @@ public Action ArenaRoundStart(Event event, const char[] name, bool dontBroadcast
 		}
 	}
 	gamemode.iTotalMaxHealth = 0;
-	int bosscount = gamemode.CountBosses(true);
+	int bosscount = gamemode.CountBosses(false);
 
 	//BaseBoss bosses[34];	// There's no way almost everybody can be an overpowered boss...
 	ArrayList bosses = new ArrayList();

--- a/addons/sourcemod/scripting/vsh2.sp
+++ b/addons/sourcemod/scripting/vsh2.sp
@@ -484,6 +484,7 @@ public void OnAllPluginsLoaded()
 int
 	tf_arena_use_queue,
 	mp_teams_unbalance_limit,
+	mp_forceautoteam,
 	tf_arena_first_blood,
 	mp_forcecamera
 ;
@@ -510,7 +511,9 @@ public void OnConfigsExecuted()
 		
 		FindConVar("tf_arena_use_queue").IntValue = 0;
 		FindConVar("mp_teams_unbalance_limit").IntValue = 0;
+		FindConVar("mp_forceautoteam").IntValue = 0;
 		FindConVar("mp_teams_unbalance_limit").IntValue =  cvarVSH2[FirstRound].BoolValue ? 0 : 1;
+		FindConVar("mp_forceautoteam").IntValue = cvarVSH2[FirstRound].BoolValue ? 0 : 1;
 		FindConVar("tf_arena_first_blood").IntValue =  0;
 		FindConVar("mp_forcecamera").IntValue =  0;
 		FindConVar("tf_scout_hype_pep_max").FloatValue =  100.0;
@@ -626,11 +629,14 @@ public void OnMapStart()
 			DispatchSpawn(gamemode.iHealthBar);
 	}
 	gamemode.iRoundCount = 0;
+    gamemode.iRoundState = StateDisabled;
+    gamemode.hNextBoss = view_as< BaseBoss >(0);
 }
 public void OnMapEnd()
 {
 	FindConVar("tf_arena_use_queue").IntValue = tf_arena_use_queue;
 	FindConVar("mp_teams_unbalance_limit").IntValue = mp_teams_unbalance_limit;
+	FindConVar("mp_forceautoteam").IntValue = mp_forceautoteam;
 	FindConVar("tf_arena_first_blood").IntValue = tf_arena_first_blood;
 	FindConVar("mp_forcecamera").IntValue = mp_forcecamera;
 	FindConVar("tf_scout_hype_pep_max").FloatValue = tf_scout_hype_pep_max;


### PR DESCRIPTION
Turns on mp_forceautoteam to 1 to prevent people getting stuck in spectator.
Turns off mp_forceautoteam when the first official VSH round starts.
Changes the boss count from alive bosses to any bosses. Prevents count from being 0 while there would still be bosses active. This would cause a Divide by zero error and wouldn't switch the boss player to the correct team. (1)
Added check to UberDeployed event during setup/first round, previously could be used to get an infinite uber charge that lasted forever due to bad timer handling.


(1) 
```
L 03/19/2019 - 17:16:05: [SM] Exception reported: Divide by zero
L 03/19/2019 - 17:16:05: [SM] Blaming: vsh2.smx
L 03/19/2019 - 17:16:05: [SM] Call stack trace:
L 03/19/2019 - 17:16:05: [SM]   [1] Line 392, modules/events.sp::ArenaRoundStart
```