### PR TITLE
Remove extra call to downloads

### DIFF
--- a/addons/sourcemod/scripting/vsh2.sp
+++ b/addons/sourcemod/scripting/vsh2.sp
@@ -335,7 +335,7 @@ public void OnPluginStart()
 	g_vsh2.m_hCookies[MusicOpt] = new Cookie("vsh2_music_settings", "HaleMusic setting.", CookieAccess_Public);
 	
 	/// in handler.sp
-	ManageDownloads();
+	//ManageDownloads();
 	
 	for( int i=MaxClients; i; --i ) {
 		if( !IsClientInGame(i) )


### PR DESCRIPTION
This is redundant, and will run twice during late loads (OnMapStart fires anyway when late loading). Might solve this off-chance error https://forums.alliedmods.net/showpost.php?p=2687627&postcount=118