### PR TITLE
fix iPresetType cookie handling

### DIFF
--- a/addons/sourcemod/scripting/modules/base.sp
+++ b/addons/sourcemod/scripting/modules/base.sp
@@ -93,7 +93,7 @@ methodmap BaseFighter {	/** Player Interface that Opposing team and Boss team de
 			}
 			char setboss[6];
 			g_vsh2.m_hCookies[BossOpt].Get(player, setboss, sizeof(setboss));
-			int bossType = StringToInt(setboss);
+			int bossType = (setboss[0] != '\0') ? StringToInt(setboss) : -1; /// fallback to -1 aka random/unset on empty-string
 			g_vsh2.m_hPlayerFields[player].SetValue("iPresetType", bossType);
 			return bossType;
 		}


### PR DESCRIPTION
Currently missing iPresetType cookie defaults to the first boss index 0, because unset cookies default to empty-string and StringToInt of empty-string is 0, so we should check if the string is empty and then default to -1 instead, which is the unset/random boss type.