### PR TITLE
VSH2_GetBossID native

### DIFF
--- a/addons/sourcemod/scripting/include/vsh2.inc
+++ b/addons/sourcemod/scripting/include/vsh2.inc
@@ -597,6 +597,14 @@ native int VSH2_GetRandomBossType(int[] boss_filter, int filter_size=0);
 native StringMap VSH2_GetBossIDs(bool registered_only=false);
 
 /**
+ * Returns the ID of a specific bossname, useful for example finding IDs of companions bosses at runtime.
+ * @param boss_name: short name of the boss you want to find
+ * @return           boss ID as an integer
+ * @note             returns -1 if boss was not found
+ */
+native int VSH2_GetBossID(const char boss_name[MAX_BOSS_NAME_SIZE])
+
+/**
  * Stops the VSH2 background music at will.
  * @param reset_time: resets the music time so that 'OnMusic' hook can be called again.
  * @noreturn
@@ -851,6 +859,7 @@ public void __pl_vsh2_SetNTVOptional()
 	MarkNativeAsOptional("VSH2_GetMaxBosses");
 	MarkNativeAsOptional("VSH2_GetRandomBossType");
 	MarkNativeAsOptional("VSH2_GetBossIDs");
+	MarkNativeAsOptional("VSH2_GetBossID");
 	MarkNativeAsOptional("VSH2_StopMusic");
 	
 	MarkNativeAsOptional("VSH2GameMode_GetProperty");

--- a/addons/sourcemod/scripting/modules/handler.sp
+++ b/addons/sourcemod/scripting/modules/handler.sp
@@ -1343,6 +1343,7 @@ public void ManageResetVariables(const BaseBoss base)
 	base.iMaxHealth = 0;
 	base.iShieldDmg = 0;
 	base.iClimbs = 0;
+	base.bSuperCharge = false;
 }
 public void ManageEntityCreated(const int entity, const char[] classname)
 {

--- a/addons/sourcemod/scripting/vsh2.sp
+++ b/addons/sourcemod/scripting/vsh2.sp
@@ -1163,6 +1163,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	CreateNative("VSH2_UnhookEx", Native_UnhookEx);
 	CreateNative("VSH2_GetRandomBossType", Native_GetRandomBossType);
 	CreateNative("VSH2_GetBossIDs", Native_GetBossIDs);
+	CreateNative("VSH2_GetBossID", Native_GetBossID);
 	CreateNative("VSH2_StopMusic", Native_StopMusic);
 	
 	CreateNative("VSH2Player.VSH2Player", Native_VSH2Instance);
@@ -1429,6 +1430,22 @@ public any Native_GetBossIDs(Handle plugin, int numParams)
 	if( !boss_map.Size )
 		delete boss_map;
 	return boss_map;
+}
+
+public int Native_GetBossID(Handle plugin, int numParams)
+{
+	char bossname[MAX_BOSS_NAME_SIZE]; GetNativeString(1, bossname, MAX_BOSS_NAME_SIZE);
+
+	for( int i; i<g_vsh2.m_hBossesRegistered.Length; i++ ) {
+		BossModule module;
+		g_vsh2.m_hBossesRegistered.GetArray(i, module, sizeof(module));
+
+		if( !strcmp(module.name, bossname) )
+			return i + MaxDefaultVSH2Bosses;
+	}
+
+	/// -1 == boss not found
+	return -1;
 }
 
 public int Native_StopMusic(Handle plugin, int numParams)


### PR DESCRIPTION
Currently finding the ID of a particular boss module, for example to find your companion boss is very cumbersome. You have to:
1. Call GetBossIDs and construct a stringmap with all bosses (expensive!)
2. Check if your boss is in the stringmap
3. Copy the value of the k/v pair to an integer
4. Remember to destroy the stringmap

with GetBossID you can just
`int luigi_id = VSH2_GetBossID("luigi_boss")`
and check if the number is -1 to make sure it was found.