### PR TITLE
FF2 Compatibility

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -16,7 +16,6 @@
 #pragma semicolon        1
 #pragma newdecls         required
 
-
 public Plugin myinfo = {
 	name           = "VSH2/FF2 Compatibility Engine",
 	author         = "Nergal/Assyrianic, BatFoxKid and 01Pollux",
@@ -25,30 +24,31 @@ public Plugin myinfo = {
 	url            = "https://github.com/VSH2-Devs/Vs-Saxton-Hale-2"
 };
 
-
-enum m_iRageInfo {
-	iRageMode,
-	iRageMin,
-	iRageMax
-};
-
 enum {
 	FF2OnMusic,
 	FF2OnMusic2,
 	FF2OnSpecial,
-	FF2OnAlive,
 	FF2OnLoseLife,
 	FF2OnBackstab,
 	FF2OnPreAbility,
 	FF2OnAbility,
 	FF2OnQueuePoints,
-	FF2OnHurtShield,
 	FF2PostRoundStart,
 	FF2OnBossJarated,
 	MaxFF2Forwards
 };
 
+enum struct FF2ConVars {
+	ConVar m_enabled;
+	ConVar m_version;
+	ConVar m_fljarate;
+	ConVar m_flairblast;
+	ConVar m_flmusicvol;
+	ConVar m_packname;
+}
+
 enum struct FF2CompatPlugin {
+	FF2ConVars	   m_cvars;
 	ConfigMap	   m_charcfg;
 	GlobalForward  m_forwards[MaxFF2Forwards];
 	bool           m_vsh2;
@@ -57,16 +57,7 @@ enum struct FF2CompatPlugin {
 	bool           m_queueChecking;
 }
 
-enum struct VSH2ConVars {
-	ConVar m_enabled;
-	ConVar m_version;
-	ConVar m_fljarate;
-	ConVar m_flairblast;
-	ConVar m_flmusicvol;
-}
-
 FF2CompatPlugin ff2;
-VSH2ConVars     vsh2cvars;
 VSH2GameMode    vsh2_gm;
 
 #include "modules/ff2/utils.sp"
@@ -74,29 +65,17 @@ VSH2GameMode    vsh2_gm;
 #include "modules/ff2/formula_parser.sp"
 #include "modules/ff2/vsh2_bridge.sp"
 #include "modules/ff2/natives.sp"
+#include "modules/ff2/console.sp"
 
-public void OnPluginStart()
-{
-	/// ConVars subplugins depend on
-	CreateConVar("ff2_oldjump", "1", "Use old Saxton Hale jump equations", _, true, 0.0, true, 1.0);
-	CreateConVar("ff2_base_jumper_stun", "0", "Whether or not the Base Jumper should be disabled when a player gets stunned", _, true, 0.0, true, 1.0);
-	CreateConVar("ff2_solo_shame", "0", "Always insult the boss for solo raging", _, true, 0.0, true, 1.0);
-	
-	Reg_ConCmds();
-}
 
 public void OnLibraryAdded(const char[] name) {
 	if( StrEqual(name, "VSH2") ) {
+		
 		ff2.m_vsh2 = true;
-		
 		ff2.m_charcfg = new ConfigMap("data/freak_fortress_2/characters.cfg");
-		InitVSH2Bridge();
 		
-		vsh2cvars.m_enabled = FindConVar("vsh2_enabled");
-		vsh2cvars.m_version = FindConVar("vsh2_version");
-		vsh2cvars.m_fljarate = FindConVar("vsh2_jarate_rage");
-		vsh2cvars.m_flairblast = FindConVar("vsh2_airblast_rage");
-		vsh2cvars.m_flmusicvol = FindConVar("vsh2_music_volume");
+		InitConVars();
+		InitVSH2Bridge();
 		
 		for( int i=MaxClients; i; i-- )
 			if( 0 < i <= MaxClients && IsClientInGame(i) )
@@ -106,14 +85,33 @@ public void OnLibraryAdded(const char[] name) {
 	}
 }
 
+public void OnPluginEnd()
+{
+	if( ff2.m_vsh2 ) {
+		
+		UnloadFF2Plugins();
+		ff2.m_vsh2 = false;
+		
+		RemoveVSH2Bridge();
+		DeleteCfg(ff2.m_charcfg);
+	}
+}
+
+public void OnLibraryRemoved(const char[] name) {
+	if( StrEqual(name, "VSH2") && ff2.m_vsh2) {
+		
+		UnloadFF2Plugins();
+		ff2.m_vsh2 = false;
+		
+		RemoveVSH2Bridge();
+		DeleteCfg(ff2.m_charcfg);
+	}
+}
+
 public void NextFrame_InitFF2Player(int client)
 {
 	FF2Player player = FF2Player(client);
-	
 	player.iMaxLives = 0;
-	player.iRageDmg = 0;
-	player.iShieldId = -1;
-	player.flShieldHP = 0.0;
 }
 
 public void OnClientPutInServer(int client)
@@ -123,34 +121,36 @@ public void OnClientPutInServer(int client)
 	RequestFrame(NextFrame_InitFF2Player, client);
 }
 
-public void OnLibraryRemoved(const char[] name) {
-	if( StrEqual(name, "VSH2") ) {
-		ff2.m_vsh2 = false;
-		
-		RemoveVSH2Bridge();
-		DeleteCfg(ff2.m_charcfg);
-		UnloadFF2Plugins();
-	}
-}
-
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
 	InitNatives();
 	
-	ff2.m_forwards[FF2OnMusic] = 		new GlobalForward("FF2_OnMusic", ET_Hook, Param_String, Param_FloatByRef);
-	ff2.m_forwards[FF2OnMusic2] = 		new GlobalForward("FF2_OnMusic2", ET_Hook, Param_String, Param_FloatByRef, Param_String, Param_String);
-	ff2.m_forwards[FF2OnSpecial] = 		new GlobalForward("FF2_OnSpecialSelected", ET_Hook, Param_CellByRef, Param_String, Param_Cell);
-	ff2.m_forwards[FF2OnAlive] = 		new GlobalForward("FF2_OnAlivePlayersChanged", ET_Hook, Param_Cell, Param_Cell);
-	ff2.m_forwards[FF2OnLoseLife] = 	new GlobalForward("FF2_OnLoseLife", ET_Hook, Param_Cell, Param_CellByRef, Param_Cell);
-	ff2.m_forwards[FF2OnBackstab] = 	new GlobalForward("FF2_OnBackStabbed", ET_Hook, Param_Cell, Param_Cell, Param_Cell);
-	ff2.m_forwards[FF2OnPreAbility] = 	new GlobalForward("FF2_PreAbility", ET_Hook, Param_Cell, Param_String, Param_String, Param_Cell, Param_CellByRef);
-	ff2.m_forwards[FF2OnAbility] = 		new GlobalForward("FF2_OnAbility", ET_Hook, Param_Cell, Param_String, Param_String, Param_Cell);
-	ff2.m_forwards[FF2OnQueuePoints] = 	new GlobalForward("FF2_OnAddQueuePoints", ET_Hook, Param_Array);
-	ff2.m_forwards[FF2OnHurtShield] = 	new GlobalForward("FF2_OnHurtShield", ET_Hook, Param_Cell, Param_CellByRef, Param_Cell, Param_Cell, Param_CellByRef);
-	ff2.m_forwards[FF2PostRoundStart] = 	new GlobalForward("FF2_OnPostRoundStart", ET_Ignore, Param_Array, Param_Cell, Param_Array, Param_Cell);
-	ff2.m_forwards[FF2OnBossJarated] = 	new GlobalForward("FF2_OnBossJarated", ET_Hook, Param_Cell, Param_Cell, Param_FloatByRef);
+	ff2.m_forwards[FF2OnMusic]		= new GlobalForward("FF2_OnMusic", ET_Hook, Param_String, Param_FloatByRef);
+	ff2.m_forwards[FF2OnMusic2]		= new GlobalForward("FF2_OnMusic2", ET_Hook, Param_String, Param_FloatByRef, Param_String, Param_String);
+	ff2.m_forwards[FF2OnSpecial]		= new GlobalForward("FF2_OnBossSelected", ET_Hook, Param_Cell, Param_String, Param_Cell);
+	ff2.m_forwards[FF2OnLoseLife]		= new GlobalForward("FF2_OnLoseLife", ET_Hook, Param_Cell, Param_CellByRef, Param_Cell);
+	ff2.m_forwards[FF2OnBackstab]		= new GlobalForward("FF2_OnBackStabbed", ET_Hook, Param_Cell, Param_Cell);
+	ff2.m_forwards[FF2OnPreAbility]		= new GlobalForward("FF2_PreAbility", ET_Hook, Param_Cell, Param_String, Param_String, Param_Cell, Param_CellByRef);
+	ff2.m_forwards[FF2OnAbility]		= new GlobalForward("FF2_OnAbility", ET_Hook, Param_Cell, Param_String, Param_String, Param_Cell);
+	ff2.m_forwards[FF2OnQueuePoints]	= new GlobalForward("FF2_OnAddQueuePoints", ET_Hook, Param_Array);
+	ff2.m_forwards[FF2PostRoundStart]	= new GlobalForward("FF2_OnPostRoundStart", ET_Ignore, Param_Array, Param_Cell, Param_Array, Param_Cell);
+	ff2.m_forwards[FF2OnBossJarated]	= new GlobalForward("FF2_OnBossJarated", ET_Hook, Param_Cell, Param_Cell, Param_FloatByRef);
 	
 	RegPluginLibrary("freak_fortress_2");
 	
 	return APLRes_Success;
 }
+
+
+#if defined _smac_included
+public Action SMAC_OnCheatDetected(int client, const char[] module, DetectionType type, Handle info)
+{
+	if( type == Detection_CvarViolation ) {
+		FF2Player player = FF2Player(client);
+		if( player.GetPropInt("bNotifySMAC_CVars") ) {
+			return Plugin_Stop;
+		}
+	}
+	return Plugin_Continue;
+}
+#endif

--- a/addons/sourcemod/scripting/freaks/ff2_vsh2defaults.sp
+++ b/addons/sourcemod/scripting/freaks/ff2_vsh2defaults.sp
@@ -1,0 +1,1516 @@
+/*
+	Default Abilities Pack:
+
+	Rages:
+	rage_cbs_bowrage
+	rage_cloneattack
+	rage_explosive_dance
+	rage_instant_teleport
+	rage_tradespam
+	rage_matrix_attack
+	rage_new_weapon
+	rage_overlay
+	rage_stun
+	rage_stunsg
+	rage_uber
+
+	Charges:
+	special_democharge
+
+	Specials:
+	model_projectile_replace
+	spawn_many_objects_on_death
+	spawn_many_objects_on_kill
+	special_cbs_multimelee
+	special_dissolve
+	special_dropprop
+	special_noanims
+*/
+
+#define FF2_USING_AUTO_PLUGIN
+
+#include <tf2_stocks>
+#include <sdkhooks>
+#include <morecolors>
+#include <freak_fortress_2>
+#include "modules/ff2/formula_parser.sp"
+
+#undef REQUIRE_PLUGIN
+#tryinclude <smac>
+#define REQUIRE_PLUGIN
+
+#pragma semicolon 1
+#pragma newdecls required
+
+#define MAXCLIENTS MAXPLAYERS + 1
+typedef AbilityPoolFn = function void(const FF2Player player);
+
+static FF2GameMode ff2_gm;
+
+enum struct _ConVars {
+	ConVar sv_cheats;
+	ConVar host_timescale;
+	ConVar mp_friendlyfire;
+	ConVar ff2_base_jumper_stun;
+	ConVar ff2_strangewep;
+	ConVar ff2_solo_shame;
+	
+	void Init()
+	{
+		this.sv_cheats				= FindConVar("sv_cheats");
+		this.host_timescale			= FindConVar("host_timescale");
+		this.mp_friendlyfire 		= FindConVar("mp_friendlyfire");
+		this.ff2_base_jumper_stun 	= FindConVar("ff2_base_jumper_stun");
+		this.ff2_strangewep 		= FindConVar("ff2_strangewep");
+		this.ff2_solo_shame 		= FindConVar("ff2_solo_shame");
+	}
+}
+_ConVars m_ConVars;
+
+
+#define EXPLOSIVE_DANCE_ABILITY	"rage_explosive_dance"	
+enum struct _ExplosiveDance_t
+{
+	int iNumExplosion;
+	float flDamage;
+	float flRange;
+	
+	void Init(FF2Player player)
+	{
+		if(player.HasAbility(this_plugin_name, EXPLOSIVE_DANCE_ABILITY)) {
+			this.iNumExplosion = player.GetArgI(this_plugin_name, EXPLOSIVE_DANCE_ABILITY, "count", 35);
+			this.flDamage = player.GetArgF(this_plugin_name, EXPLOSIVE_DANCE_ABILITY, "damage", 180.0);
+			this.flRange = player.GetArgF(this_plugin_name, EXPLOSIVE_DANCE_ABILITY, "distance", 350.0);
+		}
+	}
+}
+_ExplosiveDance_t ExplosiveDance[MAXCLIENTS];
+
+
+#define NEW_WEAPON_ABILITY 		"rage_new_weapon"
+
+#define STUN_ABILITY			"rage_stun"
+
+#define STUN_BUILDING_ABILITY	"rage_stunsg"
+	
+#define UBER_ABILITY			"rage_uber"
+
+#define CBS_BOW_ABILITY			"rage_cbs_bowrage"
+
+#define CLONE_ATK_ABILITY 		"rage_cloneattack"
+
+#define INSTANT_TELE_ABILITY 	"rage_instant_teleport"
+enum struct _InstantTele_t
+{
+	int flags;
+	float slowdown;
+	float time;
+}
+
+#define TRADE_SPAWN_ABILITY 	"rage_tradespam"
+
+#define MATRIX_ABILITY			"rage_matrix_attack"
+#define SOUND_SLOW_MO_START		"replay/enterperformancemode.wav"
+#define SOUND_SLOW_MO_END		"replay/exitperformancemode.wav"
+enum struct _MatrixAbility_t {
+	Handle timer;
+	int iOldTarget;
+	
+	void InValidate()
+	{
+		this.timer = null;
+		this.iOldTarget = 0;
+	}
+	
+	bool Validate(int iCurTarget)
+	{
+		if( iCurTarget != this.iOldTarget ) {
+			this.iOldTarget = iCurTarget;
+			return true;
+		}
+		return false;
+	}
+}
+_MatrixAbility_t ma_data;
+
+#define OVERLAY_ABILITY			"rage_overlay"
+
+#define DEMOCHARGE_ABILITY		"special_democharge"
+enum struct _DemoCharge_t {
+	bool bThinkHooked;
+	float flNextThink[MAXCLIENTS];
+}
+_DemoCharge_t democharge;
+
+
+/// Specials
+#define PROJECTILE_ABILITY 		"model_projectile_replace"
+#define OBJECTS_DEATH			"spawn_many_objects_on_death"
+#define OBJECTS_KILL			"spawn_many_objects_on_kill"
+#define CBS_MULTIMELEE			"special_cbs_multimelee"
+#define DISSOLVE				"special_dissolve"
+#define DROP_PROP				"special_dropprop"
+#define NO_ANIMS				"special_noanims"
+
+
+enum struct Function_t { 
+	Function fn; 
+}
+methodmap AbilityPool_t < StringMap
+{
+	public AbilityPool_t()
+	{
+		return view_as<AbilityPool_t>(new StringMap());
+	}
+	
+	public void FindAndStartCall(const char[] name, const FF2Player player)
+	{
+		Function_t _fn;
+		if( this.GetArray(name, _fn, sizeof(Function_t)) ) {
+			Call_StartFunction(null, _fn.fn);
+			Call_PushCell(player);
+			Call_Finish();
+		}
+	}
+	
+	public void Register(const char[] name, AbilityPoolFn fn)
+	{
+		Function_t _fn; _fn.fn = fn;
+		this.SetArray(name, _fn, sizeof(Function_t));
+	}
+}
+AbilityPool_t AbilityPool;
+
+
+
+public Plugin myinfo =
+{
+	name		=	"Unofficial Freak Fortress 2: Defaults",
+	author		=	"Many many people",
+	description	=	"FF2: Combined subplugin of default abilities",
+	version		=	"0.7.1"
+};
+
+public void OnMapStart()
+{
+	PrecacheSound(SOUND_SLOW_MO_START);
+	PrecacheSound(SOUND_SLOW_MO_END);
+	PrecacheSound("ui/notification_alert.wav");
+}
+
+public void OnPluginStart2()
+{
+	m_ConVars.Init();
+	
+	AbilityPool = new AbilityPool_t();
+	
+	AbilityPool.Register(EXPLOSIVE_DANCE_ABILITY, 	Explosive_Dance);
+	AbilityPool.Register(NEW_WEAPON_ABILITY, 		Rage_New_Weapon);
+	AbilityPool.Register(STUN_ABILITY,		 		Rage_Stun);
+	AbilityPool.Register(STUN_BUILDING_ABILITY,		Rage_Stun_Building);
+	AbilityPool.Register(UBER_ABILITY,		 		Rage_Uber);
+	AbilityPool.Register(CBS_BOW_ABILITY,			Rage_CBS_Bow);
+	AbilityPool.Register(CLONE_ATK_ABILITY,			Rage_CloneAttack);
+	AbilityPool.Register(INSTANT_TELE_ABILITY, 		Rage_Instant_Tele);
+	AbilityPool.Register(TRADE_SPAWN_ABILITY, 		Rage_Trade_Spam);
+	AbilityPool.Register(MATRIX_ABILITY,			Rage_Matrix);
+	AbilityPool.Register(OVERLAY_ABILITY,			Rage_Overlay);
+	
+	VSH2_Hook(OnPlayerKilled, 		_OnPlayerKilled);
+	VSH2_Hook(OnRoundStart,			_OnRoundStart);
+	VSH2_Hook(OnRoundEndInfo, 		_OnRoundEnd);
+	VSH2_Hook(OnMinionInitialized,  _OnMinionInitialized);
+	
+	if(ff2_gm.RoundState == StateRunning) {
+		
+		FF2Player[] bosses = new FF2Player[MaxClients + 1];
+		FF2Player[] mercs = new FF2Player[MaxClients + 1];
+		int b_count = FF2GameMode.GetBosses(bosses, false);
+		int m_count = FF2GameMode.GetBosses(mercs, false);
+		
+		_OnRoundStart(bosses, b_count, mercs, m_count);
+	}
+}
+
+public void OnPluginEnd()
+{
+	delete AbilityPool;
+	
+	VSH2_Unhook(OnPlayerKilled, 	 _OnPlayerKilled);
+	VSH2_Unhook(OnRoundStart, 		 _OnRoundStart);
+	VSH2_Unhook(OnRoundEndInfo, 	 _OnRoundEnd);
+	VSH2_Unhook(OnMinionInitialized, _OnMinionInitialized);
+}
+
+public void FF2_OnAbility2(const FF2Player player, const char[] abilityName, FF2CallType_t calltype)
+{
+	AbilityPool.FindAndStartCall(abilityName, player);
+}
+
+
+public void OnEntityCreated(int entity, const char[] classname)
+{
+	if( !StrContains(classname, "tf_projectile") )
+		SDKHook(entity, SDKHook_SpawnPost, OnProjectileSpawned);
+}
+
+public void OnProjectileSpawned(int entity)
+{
+	int launcher = GetEntPropEnt(entity, Prop_Send, "m_hLauncher");
+	if( launcher < 0 )
+		return;
+	
+	int client = GetEntPropEnt(launcher, Prop_Send, "m_hOwnerEntity");
+	if ( client > 0 && IsClientInGame(client) ) {
+		FF2Player player = FF2Player(client);
+		if( player.HasAbility(this_plugin_name, PROJECTILE_ABILITY) ) {
+			static char projectile[PLATFORM_MAX_PATH], classname[PLATFORM_MAX_PATH];
+			if( player.GetArgS(this_plugin_name, PROJECTILE_ABILITY, "projectile", projectile, sizeof(projectile)) && 
+				GetEntityClassname(entity, classname, sizeof(classname)) && 
+				StrContains(classname, projectile) != -1 ) {
+				
+				player.GetArgS(this_plugin_name, PROJECTILE_ABILITY, "model", classname, sizeof(classname));
+				if( !IsModelPrecached(classname) ) {
+					if( FileExists(classname, true) && classname[0] )
+						PrecacheModel(classname);
+					else {
+						FF2_ReportError(player, "[Boss] Model '%s' doesn't exist!  Please check config", classname);
+						return;
+					}
+				}
+				SetEntityModel(entity, classname);
+			}
+		}
+	}
+}
+
+
+/* VSH2 Events */
+public void _OnRoundStart(const VSH2Player[] bosses, const int boss_count, const VSH2Player[] red_players, const int red_count)
+{
+	FF2Player player;
+	for(int i = 0; i < boss_count; i++) {
+		player = ToFF2Player(bosses[i]);
+		ExplosiveDance[player.index].Init(player);
+		
+		if( player.HasAbility(this_plugin_name, DEMOCHARGE_ABILITY) && !democharge.bThinkHooked ) {
+			VSH2_Hook(OnBossThinkPost, _RunDemoChargeThink);
+			democharge.bThinkHooked = true;
+		}
+	}
+	
+	CreateTimer(0.41, Timer_Disable_Anims, .flags = TIMER_FLAG_NO_MAPCHANGE);
+	CreateTimer(9.31, Timer_Disable_Anims, .flags = TIMER_FLAG_NO_MAPCHANGE);
+}
+
+public void _OnMinionInitialized(const VSH2Player minion, const VSH2Player vsh2_owner)
+{
+	FF2Player owner = ToFF2Player(vsh2_owner);
+	if( !FF2GameMode.Validate(vsh2_owner) )
+		return;
+	
+	static char classname[64], model[PLATFORM_MAX_PATH];
+	
+	int health = 250;
+	
+	/// Formula parser by nergal
+	if( owner.GetArgS(this_plugin_name, CLONE_ATK_ABILITY, "health", model, sizeof(model)) ) {
+		health = RoundToNearest(ParseFormula(model, ff2_gm.iLivingReds));
+	}
+	
+	owner.GetArgS(this_plugin_name, CLONE_ATK_ABILITY, "attributes", model, sizeof(model));
+	
+	int ammo = owner.GetArgI(this_plugin_name, CLONE_ATK_ABILITY, "ammo", -1);
+	int clip = owner.GetArgI(this_plugin_name, CLONE_ATK_ABILITY, "clip", -1);
+
+	int client = minion.index;
+	/// Handle minions class
+	{
+		int class = owner.GetArgI(this_plugin_name, CLONE_ATK_ABILITY, "class");
+		TF2_SetPlayerClass(client, view_as<TFClassType>(class), .persistent = false);
+	}
+	minion.RemoveAllItems();
+	
+#if defined _tf2attributes_included
+	if( VSH2GameMode.GetPropInt("bTF2Attribs") )
+		TF2Attrib_RemoveAll(client);
+#endif
+	
+	/// Handle minions weapon
+	if(	owner.GetArgI(this_plugin_name, CLONE_ATK_ABILITY, "weapon mode") && 
+		owner.GetArgS(this_plugin_name, CLONE_ATK_ABILITY, "classname",  classname, sizeof(classname)) ) {
+		int index = owner.GetArgI(this_plugin_name, CLONE_ATK_ABILITY, "index", 191);
+		int weapon = minion.SpawnWeapon( classname, 
+										 index, 
+										 100, 
+										 5, 
+										 model /* attributes */);
+		if( IsValidEntity(weapon) ) {
+			SetEntPropEnt(client, Prop_Send, "m_hActiveWeapon", weapon);
+			SetEntProp(weapon, Prop_Send, "m_iWorldModelIndex", -1);
+			
+			if( StrEqual(classname, "tf_weapon_builder") && index != 735 )  //PDA, normal sapper
+			{
+				for( int i = 0; i < 4; i++ )
+					SetEntProp(weapon, Prop_Send, "m_aBuildableObjectTypes", 0, .element = i);
+			}
+			else if( StrEqual(classname, "tf_weapon_sapper") || index == 735 )  //Sappers, normal sapper
+			{
+				SetEntProp(weapon, Prop_Send, "m_iObjectType", 3);
+				SetEntProp(weapon, Prop_Data, "m_iSubType", 3);
+				for( int i = 0; i < 4; i++ )
+					SetEntProp(weapon, Prop_Send, "m_aBuildableObjectTypes", 0, .element = i);
+			}
+	
+			if( ammo >= 0 || clip >= 0 )
+				FF2_SetAmmo(client, weapon, ammo, clip);
+		}
+	}
+	
+	if(health)
+	{
+		SetEntProp(client, Prop_Data, "m_iMaxHealth", health);
+		SetEntityHealth(client, health);
+	}
+	
+	{
+		static float position[3], velocity[3];
+		GetEntPropVector(owner.index, Prop_Data, "m_vecOrigin", position);
+		
+		velocity[0] = GetRandomFloat(300.0, 500.0) * (GetRandomInt(0, 1) ? 1:-1);
+		velocity[1] = GetRandomFloat(300.0, 500.0) * (GetRandomInt(0, 1) ? 1:-1);
+		velocity[2] = GetRandomFloat(300.0, 500.0);
+		
+		TeleportEntity(client, position, NULL_VECTOR, velocity);
+		TF2_AddCondition(client, TFCond_Ubercharged, 2.0);
+	}
+	
+	if( !owner.GetArgI(this_plugin_name, CLONE_ATK_ABILITY, "custom model") ) {
+		owner.GetString("model", model, sizeof(model));
+	} else owner.GetArgS(this_plugin_name, CLONE_ATK_ABILITY, "model",  model, sizeof(model));
+	
+	if( model[0] ) {
+		SetVariantString(model);
+		AcceptEntityInput(client, "SetCustomModel");
+		SetEntProp(client, Prop_Send, "m_bUseClassAnimations", 1);
+	}
+	
+	if( owner.GetName(classname) )
+		PrintHintText(client, "Now you are %s's minion! Attack other team", classname);
+	
+	SetEntProp(client, Prop_Send, "m_nBody", 0);
+}
+
+public void _OnRoundEnd(const VSH2Player vsh2_player, bool bossBool, char message[MAXMESSAGE])
+{
+	if( !FF2GameMode.Validate(vsh2_player) )
+		return;
+	
+	if( ma_data.timer ) {
+		TriggerTimer(ma_data.timer);
+	}
+	
+	if( ToFF2Player(vsh2_player).HasAbility(this_plugin_name, DEMOCHARGE_ABILITY) && democharge.bThinkHooked ) {
+		VSH2_Unhook(OnBossThinkPost, _RunDemoChargeThink);
+		democharge.bThinkHooked = false;
+	}
+}
+
+public void _RunDemoChargeThink(const VSH2Player vsh2_player)
+{
+	int index = vsh2_player.index;
+	if( index <= 0 || !(GetClientButtons(index) & IN_RELOAD) )
+		return;
+	
+	if( democharge.flNextThink[index] > GetGameTime() )
+		return;
+	
+	FF2Player player = ToFF2Player(vsh2_player);
+	float delay = ToFF2Player(player).GetArgF(this_plugin_name, DEMOCHARGE_ABILITY, "delay");
+	
+	if( delay < 0.1 )
+		Do_DemoCharge(null, player);
+	else {
+		democharge.flNextThink[index] = GetGameTime() + delay;
+		CreateTimer(delay, Do_DemoCharge, player);
+	}
+}
+
+public void _OnPlayerKilled(const VSH2Player vsh2_attacker, const VSH2Player victim, Event event)
+{
+	if( FF2GameMode.Validate(vsh2_attacker) ) {	///	attacker is the boss
+		HandleAttackerKill(ToFF2Player(victim), ToFF2Player(vsh2_attacker));
+	}
+	else if( FF2GameMode.Validate(victim) ) {	///	victim is the boss
+		HandleVictimKill(ToFF2Player(victim), event.GetInt("death_flags"));
+	}
+}
+
+
+/* New Weapon */
+void Rage_New_Weapon(const FF2Player player)
+{
+	int client = player.index;
+	if(!IsClientInGame(client) || !IsPlayerAlive(client))
+		return;
+
+	TF2_RemoveWeaponSlot(client, player.GetArgI(this_plugin_name, NEW_WEAPON_ABILITY, "weapon slot", -1));
+	
+	static char classname[64], attributes[128];
+	
+	int index = player.GetArgI(this_plugin_name, NEW_WEAPON_ABILITY, "index", -1);
+	if( !player.GetArgS(this_plugin_name, NEW_WEAPON_ABILITY, "classname", classname, sizeof(classname)) || index < 0 ) 
+		return;
+	
+	player.GetArgS(this_plugin_name, NEW_WEAPON_ABILITY, "attributes", attributes, sizeof(attributes));
+	
+	int weapon = player.SpawnWeapon( classname,	
+									 index,player.GetArgI(this_plugin_name, NEW_WEAPON_ABILITY, "level", 39), 
+									 player.GetArgI(this_plugin_name, NEW_WEAPON_ABILITY, "quality", 5),
+									 attributes );
+							
+	if(StrEqual(classname, "tf_weapon_builder") && index != 735)  //PDA, normal sapper
+	{
+		for(int i = 0; i < 4; i++)
+			SetEntProp(weapon, Prop_Send, "m_aBuildableObjectTypes", 1, .element = i);
+	}
+	else if(StrEqual(classname, "tf_weapon_sapper") || index == 735)  //Sappers, normal sapper
+	{
+		SetEntProp(weapon, Prop_Send, "m_iObjectType", 3);
+		SetEntProp(weapon, Prop_Data, "m_iSubType", 3);
+		for(int i = 0; i < 4; i++)
+			SetEntProp(weapon, Prop_Send, "m_aBuildableObjectTypes", 0, .element = i);
+	}
+
+	if(player.GetArgF(this_plugin_name, NEW_WEAPON_ABILITY, "force switch"))
+		SetEntPropEnt(client, Prop_Send, "m_hActiveWeapon", weapon);
+
+	int ammo = player.GetArgI(this_plugin_name, NEW_WEAPON_ABILITY, "ammo", 5);
+	int clip = player.GetArgI(this_plugin_name, NEW_WEAPON_ABILITY, "clip", 7);
+	
+	if (ammo >= 0 || clip >= 0)
+		FF2_SetAmmo(client, weapon, ammo, clip);
+}
+
+
+/* Stun Player */
+void Rage_Stun(const FF2Player player)
+{
+	float delay = player.GetArgF(this_plugin_name, STUN_ABILITY, "delay", 0.0);
+	if( delay >= 0.1 )
+		CreateTimer(delay, Timer_Rage_Stun, player);
+	else
+		Timer_Rage_Stun(null, player);
+}
+
+public Action Timer_Rage_Stun(Handle timer, FF2Player cur_boss)
+{
+	int client = cur_boss.index;
+	
+	static float bossPosition[3], targetPosition[3];
+	GetEntPropVector(client, Prop_Send, "m_vecOrigin", bossPosition);
+	
+ /// Initial Duration
+	float duration = cur_boss.GetArgF(this_plugin_name, STUN_ABILITY, "duration", 5.0);
+	
+ /// Distance
+	float distance = cur_boss.GetArgF(this_plugin_name, STUN_ABILITY, "distance");
+	if(distance <= 0)
+		distance = cur_boss.RageDist(this_plugin_name, STUN_ABILITY);
+		
+ /// Stun Flags
+	char flagOverrideStr[12];
+	cur_boss.GetArgS(this_plugin_name, STUN_ABILITY, "flags", flagOverrideStr, sizeof(flagOverrideStr));
+	int flagOverride = StringToInt(flagOverrideStr, 16);
+	if( !flagOverride )
+		flagOverride = TF_STUNFLAGS_GHOSTSCARE | TF_STUNFLAG_NOSOUNDOREFFECT;
+	
+ /// Slowdown
+	float slowdown = cur_boss.GetArgF(this_plugin_name, STUN_ABILITY, "slowdown");
+	
+ /// Sound To Boss
+	bool sounds = cur_boss.GetArgI(this_plugin_name, STUN_ABILITY, "sound", 1) != 0;
+	
+ /// Particle Effect
+	static char particleEffect[48];
+	if( !cur_boss.GetArgS(this_plugin_name, STUN_ABILITY, "particle", particleEffect, sizeof(particleEffect)) )
+		particleEffect = "yikes_fx";
+		
+ /// Ignore
+	int ignore = cur_boss.GetArgI(this_plugin_name, STUN_ABILITY, "uber", 1) != 0;
+	
+ /// Friendly Fire
+	bool friendly = cur_boss.GetArgI(this_plugin_name, STUN_ABILITY, "friendly", m_ConVars.mp_friendlyfire.IntValue) != 0;
+	
+ /// Remove Parachute
+	bool removeBaseJumperOnStun = cur_boss.GetArgI(this_plugin_name, STUN_ABILITY, "basejumper", m_ConVars.ff2_base_jumper_stun.IntValue) != 0;
+	
+ /// Max Duration
+	float maxduration = cur_boss.GetArgF(this_plugin_name, STUN_ABILITY, "max", 6.0);
+	
+ /// Add Duration
+	float addduration = cur_boss.GetArgF(this_plugin_name, STUN_ABILITY, "add");
+	if( maxduration <= 0 ) {
+		maxduration = duration;
+		addduration = 0.0;
+	}
+	
+ // Solo Rage Duration
+	float soloduration = cur_boss.GetArgF(this_plugin_name, STUN_ABILITY, "solo");
+	if( soloduration <= 0 )
+		soloduration = duration;
+	
+	FF2Player[] victim_pool = new FF2Player[MaxClients + 1];
+	int count;
+	for( int target = 1; target <= MaxClients; target++ ) {
+		if( IsClientInGame(target) && IsPlayerAlive(target) && target != client && (friendly || GetClientTeam(target) != GetClientTeam(client)) ) {
+			GetEntPropVector(target, Prop_Send, "m_vecOrigin", targetPosition);
+			if( (!TF2_IsPlayerInCondition(target, TFCond_Ubercharged) 
+				|| (ignore > 0 && ignore != 2)) && (!TF2_IsPlayerInCondition(target, TFCond_MegaHeal) 
+				|| ignore > 1) && GetVectorDistance(bossPosition, targetPosition) <= distance ) {
+				victim_pool[count] = FF2Player(target);
+				count++;
+			}
+		}
+	}
+
+	if(!count)
+		return Plugin_Continue;
+	
+	if( count == 1 && (duration != soloduration || m_ConVars.ff2_solo_shame.BoolValue) ) {
+		static char bossName[64];
+		if( cur_boss.GetName(bossName) )
+			FPrintToChatAll("{blue}%s{default} used {red}solo rage{default}!", bossName);
+		
+		if( duration != soloduration )
+			duration = soloduration;
+	}
+	else {
+		duration += addduration * (count - 1);
+		if( duration > maxduration )
+			duration = maxduration;
+	}
+	
+	CreateTimer(duration, Timer_SoloRageResult, victim_pool[count - 1]);
+	
+	/// Idealy we can use FF2Player.StunPlayers() but we want to change stun particles
+	FF2Player cur_victim;
+	while(count > 0) {
+		count--;
+		cur_victim = victim_pool[count];
+		
+		if( removeBaseJumperOnStun )
+			TF2_RemoveCondition(cur_victim.index, TFCond_Parachute);
+		
+		TF2_StunPlayer(cur_victim.index, duration, slowdown, flagOverride, sounds ? client : 0);
+		
+		if( particleEffect[0] )
+			AttachParticle(cur_victim.index, particleEffect, 75.0);
+	}
+	return Plugin_Continue;
+}
+
+public Action Timer_SoloRageResult(Handle timer, FF2Player target)
+{
+	int client = target.index;
+	if( !IsClientInGame(client) || ff2_gm.RoundState != StateRunning )
+		return Plugin_Continue;
+
+	if( IsPlayerAlive(client) )
+		FPrintToChatAll("It's {red}not{default} very effective...");
+	else
+		FPrintToChatAll("It's {blue}super{default} effective...");
+
+	return Plugin_Continue;
+}
+
+
+/* Stun Building */
+enum BuildingType_t { 
+	SENTRY 		= 0b001,
+	DISPENSER 	= 0b010,
+	TELEPORTER 	= 0b100
+};
+void Rage_Stun_Building(const FF2Player player)
+{
+	int client = player.index;
+	static float bossPosition[3];
+	GetEntPropVector(client, Prop_Send, "m_vecOrigin", bossPosition);
+
+	float duration = player.GetArgF(this_plugin_name, STUN_BUILDING_ABILITY, "duration", 7.0);
+	
+	float distance = player.GetArgF(this_plugin_name, STUN_BUILDING_ABILITY, "distance");
+	if( distance <= 0 )
+		distance = player.RageDist(this_plugin_name, STUN_BUILDING_ABILITY);
+	
+	char strBuffer[48];
+	float health;
+ 	bool destroy;
+ 	
+ 	{
+ 		if( player.GetArgS(this_plugin_name, STUN_BUILDING_ABILITY, "health", strBuffer, sizeof(strBuffer)) )
+ 			health = ParseFormula(strBuffer, ff2_gm.iLivingReds);
+ 		
+ 		if( health <= 0 )
+ 			destroy = true;
+ 	}
+	
+	float ammo = player.GetArgF(this_plugin_name, STUN_BUILDING_ABILITY, "ammo", 1.0);
+	float rockets = player.GetArgF(this_plugin_name, STUN_BUILDING_ABILITY, "rocket", 1.0);
+	
+	if( player.GetArgS(this_plugin_name, STUN_BUILDING_ABILITY, "particle", strBuffer, sizeof(strBuffer)) )
+		strBuffer = "yikes_fx";
+	
+	BuildingType_t buildingtype = view_as<BuildingType_t>(player.GetArgI(this_plugin_name, STUN_BUILDING_ABILITY, "building", 0b111));
+	/**
+	 *	1 = sentry
+	 *	2 = dispenser
+	 *	4 = teleporter
+ 	 */
+	
+	bool friendly = player.GetArgI(this_plugin_name, STUN_BUILDING_ABILITY, "friendly", m_ConVars.mp_friendlyfire.IntValue) != 0;
+	
+	static char full_clsname[64];
+	
+	{
+		float buildingPos[3];
+		int building = MaxClients + 1;
+		bool target = false;
+		int other_team = GetClientTeam(client) % 2;
+		
+		while( (building = FindEntityByClassname(building, "obj_*")) != -1 ) {
+			
+			target = ((GetEntProp(building, Prop_Send, "m_nSkin") % 2) != other_team) || friendly;
+			target &= !GetEntProp(building, Prop_Send, "m_bCarried") && !GetEntProp(building, Prop_Send, "m_bPlacing");
+			
+			if( !target )
+				continue;
+			
+			if( !GetEntityClassname(building, full_clsname, sizeof(full_clsname)) )
+				continue;
+			
+			switch( full_clsname[4] ) {
+				case 's': {
+					if( !(buildingtype & SENTRY) )
+						continue;
+					target = false;
+				}
+				case 'd': {
+					if( !(buildingtype & DISPENSER) )
+						continue;
+				}
+				case 't': {
+					if( !(buildingtype & TELEPORTER) )
+						continue;
+				}
+				default: continue;
+			}
+			
+			GetEntPropVector(building, Prop_Send, "m_vecOrigin", buildingPos);
+			if( GetVectorDistance(bossPosition, buildingPos) <= distance ) {
+				if(destroy)
+				{
+					SDKHooks_TakeDamage(building, client, client, 9001.0, DMG_GENERIC, -1);
+				}
+				else
+				{
+					if( health != 1.0 )
+						SDKHooks_TakeDamage(building, client, client, GetEntProp(building, Prop_Send, "m_iMaxHealth") * health, DMG_GENERIC, -1);
+					
+					if( !target ) {
+						if( 0 <= ammo < 1.0 )
+							SetEntProp(building, Prop_Send, "m_iAmmoShells", GetEntProp(building, Prop_Send, "m_iAmmoShells") * ammo);
+					
+						if( 0 <= rockets < 1.0 )
+							SetEntProp(building, Prop_Send, "m_iAmmoRockets", GetEntProp(building, Prop_Send, "m_iAmmoRockets") * rockets);
+					}
+
+					if( duration > 0.0 ) {
+						SetEntProp(building, Prop_Send, "m_bDisabled", 1);
+						AttachParticle(building, strBuffer, 75.0, .time = duration);
+						CreateTimer(duration, Timer_EnableBuilding, EntIndexToEntRef(building), TIMER_FLAG_NO_MAPCHANGE);
+					}
+				}
+			}
+		}
+	}
+}
+
+public Action Timer_EnableBuilding(Handle timer, int ref)
+{
+	int building = EntRefToEntIndex(ref);
+	if( IsValidEntity(building) )
+		SetEntProp(building, Prop_Send, "m_bDisabled", 0);
+
+	return Plugin_Continue;
+}
+
+
+/* Rage Uber */
+void Rage_Uber(const FF2Player player)
+{
+	float duration = player.GetArgF(this_plugin_name, UBER_ABILITY, "duration", 5.0);
+	if( duration <= 0 )
+		return;
+	
+	int client = player.index;
+	TF2_AddCondition(client, TFCond_Ubercharged, duration);
+	SetEntProp(client, Prop_Data, "m_takedamage", 0);
+	CreateTimer(duration, Timer_StopUber, player, TIMER_FLAG_NO_MAPCHANGE);
+}
+
+public Action Timer_StopUber(Handle timer, FF2Player player)
+{
+	int client = player.index;
+	if( IsClientInGame(client) )
+		SetEntProp(client, Prop_Data, "m_takedamage", 2);
+	return Plugin_Continue;
+}
+
+
+/* Explosive Dance */
+void Explosive_Dance(const FF2Player player)
+{
+	SetEntityMoveType(player.index, MOVETYPE_NONE);
+	CreateTimer(0.15, Timer_Prepare_Explosion_Rage, player);
+}
+
+public Action Timer_Prepare_Explosion_Rage(Handle timer, FF2Player player)
+{
+	int client = player.index;
+	if(!IsClientInGame(client))
+		return Plugin_Continue;
+
+	if(player.GetArgI(this_plugin_name, EXPLOSIVE_DANCE_ABILITY, "taunt", true))
+		ClientCommand(client, "+taunt");
+
+	CreateTimer(player.GetArgF(this_plugin_name, EXPLOSIVE_DANCE_ABILITY, "delay", 0.12), Timer_Rage_Explosive_Dance, player, TIMER_REPEAT | TIMER_FLAG_NO_MAPCHANGE);
+
+	static float position[3];
+	GetEntPropVector(client, Prop_Data, "m_vecOrigin", position);
+
+	static char sound[PLATFORM_MAX_PATH];
+	
+	if(player.GetArgS(this_plugin_name, EXPLOSIVE_DANCE_ABILITY, "sound", sound, sizeof(sound)))
+		EmitSoundToAll(sound, client, .speakerentity = client, .origin = position);
+	
+	return Plugin_Continue;
+}
+
+public Action Timer_Rage_Explosive_Dance(Handle timer, FF2Player player)
+{
+	static int count[MAXCLIENTS];
+	int client = player.index;
+	if(!IsClientInGame(client))
+	{
+		count[client] = 0;
+		return Plugin_Stop;
+	}
+	
+	count[client]++;
+	if(count[client] <= ExplosiveDance[client].iNumExplosion && IsPlayerAlive(client))
+	{
+		SetEntityMoveType(client, MOVETYPE_NONE);
+		static float bossPosition[3], explosionPosition[3];
+		GetEntPropVector(client, Prop_Send, "m_vecOrigin", bossPosition);
+		explosionPosition[2] = bossPosition[2];
+		float range;
+		
+		for(int i; i < 3; i++)
+		{
+			int explosion = CreateEntityByName("env_explosion");
+			if(!IsValidEntity(explosion))
+				break;
+			
+			DispatchKeyValueFloat(explosion, "DamageForce", ExplosiveDance[client].flDamage);
+
+			SetEntProp(explosion, Prop_Data, "m_iMagnitude", 280, 4);
+			SetEntProp(explosion, Prop_Data, "m_iRadiusOverride", 200, 4);
+			SetEntPropEnt(explosion, Prop_Data, "m_hOwnerEntity", client);
+
+			DispatchSpawn(explosion);
+
+			explosionPosition[0] = bossPosition[0] + GetRandomFloat(-ExplosiveDance[client].flRange, ExplosiveDance[client].flRange);
+			explosionPosition[1] = bossPosition[1] + GetRandomFloat(-ExplosiveDance[client].flRange, ExplosiveDance[client].flRange);
+			
+			if(!(GetEntityFlags(client) & FL_ONGROUND)) {
+				range = ((ExplosiveDance[client].flRange * 3.0) / 7.0);
+				explosionPosition[2] = bossPosition[2] + GetRandomFloat(-range, range);
+			}
+			else {
+				range = ((ExplosiveDance[client].flRange * 2.0) / 7.0);
+				explosionPosition[2] = bossPosition[2] + GetRandomFloat(0.0, range);
+			}
+			
+			TeleportEntity(explosion, explosionPosition, NULL_VECTOR, NULL_VECTOR);
+			AcceptEntityInput(explosion, "Explode");
+			
+			RemoveEntity(explosion);
+		}
+	}
+	else
+	{
+		SetEntityMoveType(client, MOVETYPE_WALK);
+		count[client] = 0;
+		return Plugin_Stop;
+	}
+	return Plugin_Continue;
+}
+
+
+/* Instant Teleport */
+void Rage_Instant_Tele(const FF2Player player)
+{
+	static float position[3];
+	static char strflags[12];
+	static char particleEffect[48];
+	
+	float flstuntime = player.GetArgF(this_plugin_name, INSTANT_TELE_ABILITY, "stun", 2.0);
+	//bool friendly = player.GetArgI(this_plugin_name, INSTANT_TELE_ABILITY, "friendly", 1) != 0;
+	float flslowdown = player.GetArgF(this_plugin_name, INSTANT_TELE_ABILITY, "slowdown");
+	bool sounds = player.GetArgI(this_plugin_name, INSTANT_TELE_ABILITY, "sound", 1) != 0;
+	player.GetArgS(this_plugin_name, INSTANT_TELE_ABILITY, "particle",particleEffect, sizeof(particleEffect));
+	
+	int flags;
+	if(!player.GetArgS(this_plugin_name, INSTANT_TELE_ABILITY, "flags", strflags, sizeof(strflags)) 
+		|| !(flags = StringToInt(strflags, 16)) )
+		flags = TF_STUNFLAGS_GHOSTSCARE|TF_STUNFLAG_NOSOUNDOREFFECT;
+	
+	
+	int count;
+	FF2Player[] players = new FF2Player[MaxClients + 1];
+	int client = player.index
+	;
+	for( int target=1; target <= MaxClients; target++ )
+	{
+		if( IsClientInGame(target) && IsPlayerAlive(target) && target != client) {
+			players[count] = FF2Player(target);
+			count++;
+		}
+	}
+	if( !count )
+		return;
+	
+	FF2Player final_target = players[GetRandomInt(0, count - 1)];
+	int target = final_target.index;
+	
+	if(particleEffect[0]) {
+		AttachParticle(target, particleEffect);
+		AttachParticle(target, particleEffect, .battach = false);
+	}
+	
+	GetEntPropVector(target, Prop_Send, "m_vecOrigin", position);
+	SetEntPropFloat(client, Prop_Send, "m_flNextAttack", GetGameTime() + 2.0);
+	
+	if(GetEntProp(target, Prop_Send, "m_bDucked"))
+	{
+		SetEntPropVector(client, Prop_Send, "m_vecMaxs", view_as<float>({ 24.0, 24.0, 62.0 }));
+		SetEntProp(client, Prop_Send, "m_bDucked", 1);
+		SetEntityFlags(client, GetEntityFlags(client) | FL_DUCKING);
+		
+		DataPack pack;
+		CreateDataTimer(0.2, Timer_StunBoss, pack, TIMER_FLAG_NO_MAPCHANGE);
+		
+		pack.WriteCell(player);
+		pack.WriteFloat(flstuntime);
+		pack.WriteFloat(flslowdown);
+		pack.WriteCell(flags);
+	}
+	else
+	{
+		if(sounds)
+			TF2_StunPlayer(client, flstuntime, flslowdown, flags, target);
+		else
+			TF2_StunPlayer(client, flstuntime, flslowdown, flags);
+	}
+	
+	TeleportEntity(client, position, NULL_VECTOR, NULL_VECTOR);
+}
+
+public Action Timer_StunBoss(Handle timer, DataPack pack)
+{
+	int client = ToFF2Player(pack.ReadCell()).index;
+	if( !IsClientInGame(client) || !IsPlayerAlive(client) )
+		return Plugin_Continue;
+
+	float fltime = pack.ReadFloat();
+	float flslowdown = pack.ReadFloat();
+	int flags = pack.ReadCell();
+	
+	TF2_StunPlayer(client, fltime, flslowdown, flags, 0);
+	return Plugin_Continue;
+}
+
+
+/* Christian Brutal Sniper Bow */
+void Rage_CBS_Bow(const FF2Player player)
+{
+	int client = player.index;
+	TF2_RemoveWeaponSlot(client, TFWeaponSlot_Primary);
+	
+	static char attributes[64], classname[64];
+
+	player.GetArgS(this_plugin_name, CBS_BOW_ABILITY, "attributes",  attributes, sizeof(attributes));
+	if( !attributes[0] )
+	{
+		attributes = m_ConVars.ff2_strangewep.BoolValue ? 
+					 "6 ; 0.5 ; 37 ; 0.0 ; 214 ; 333 ; 280 ; 19":
+					 "6 ; 0.5 ; 37 ; 0.0 ; 280 ; 19";
+	}
+
+	int maximum = player.GetArgI(this_plugin_name, CBS_BOW_ABILITY, "max", 9);
+	int ammo = player.GetArgI(this_plugin_name, CBS_BOW_ABILITY, "ammo", 1);
+	int clip = player.GetArgI(this_plugin_name, CBS_BOW_ABILITY, "clip", 1);
+	if( !player.GetArgS(this_plugin_name, CBS_BOW_ABILITY, "classname", classname, sizeof(classname)) )
+		classname = "tf_weapon_compound_bow";
+
+	int index = player.GetArgI(this_plugin_name, CBS_BOW_ABILITY, "index", 1005);
+	int level = player.GetArgI(this_plugin_name, CBS_BOW_ABILITY, "level", 101);
+	int quality = player.GetArgI(this_plugin_name, CBS_BOW_ABILITY, "quality", 5);
+	int weapon = player.SpawnWeapon( classname, 
+									 index, 
+									 level, 
+									 quality, 
+									 attributes );
+	
+	if(player.GetArgI(this_plugin_name, CBS_BOW_ABILITY, "force switch", 1))
+		SetEntPropEnt(client, Prop_Send, "m_hActiveWeapon", weapon);
+
+	ammo *= ff2_gm.iLivingReds;	// Ammo multiplied by alive players
+	
+	if( ammo > maximum )		// Maximum or lower ammo
+		ammo = maximum;
+
+	ammo -= clip;			// Ammo subtracted by clip
+
+	while(ammo < 0 && clip >= 0)	// Remove clip until ammo or clip is zero
+	{
+		clip--;
+		ammo++;
+	}
+					// If clip is positive or zero
+	if( clip >= 0 )
+		FF2_SetAmmo(client, weapon, ammo, clip);
+}
+
+
+/* Clone Attack */
+void Rage_CloneAttack(const FF2Player player)
+{
+	int client = player.index;
+	
+	float ratio = player.GetArgF(this_plugin_name, CLONE_ATK_ABILITY, "ratio");
+	
+	int alive;
+	ArrayList list = new ArrayList();
+	FF2Player cur_target;
+	
+	for( int i = 1; i <= MaxClients; i++ ) {
+		if( IsClientInGame(i) ) {
+			cur_target = FF2Player(i);
+			
+			TFTeam team = TF2_GetClientTeam(i);
+			if( team != TF2_GetClientTeam(client) ) {
+				if( IsPlayerAlive(i) )
+					alive++;
+				else if( !cur_target.GetPropInt("bIsBoss") )  //Don't let dead bosses become clones
+				{
+					list.Push(cur_target);
+				}
+			}
+		}
+	}
+
+	int totalMinions = (ratio ? RoundToCeil(alive * ratio) : MaxClients);  //If ratio is 0, use MaxClients instead
+	
+	FF2Player minion;
+	
+	list.Sort(Sort_Random, Sort_Integer);
+	
+	while( list.Length > 0 && totalMinions > 0 ) {
+		minion = ToFF2Player(list.Get(0));
+		list.Erase(0);
+		totalMinions--;
+
+		minion.hOwnerBoss = player;
+		minion.ConvertToMinion(0.1);
+	}
+	
+	delete list;
+
+
+	int entity, owner;
+	while( (entity = FindEntityByClassname(entity, "tf_wearable")) != -1 )
+		if( (owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity")) <= MaxClients && owner > 0 && GetClientTeam(owner) == GetClientTeam(client) )
+			TF2_RemoveWearable(owner, entity);
+
+	while( (entity = FindEntityByClassname(entity, "tf_wearable_razorback")) != -1 )
+		if( (owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity")) <= MaxClients && owner > 0 && GetClientTeam(owner) == GetClientTeam(client) )
+			TF2_RemoveWearable(owner, entity);
+	
+	while( (entity = FindEntityByClassname(entity, "tf_wearable_demoshield")) != -1 )
+		if( (owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity")) <= MaxClients && owner > 0 && GetClientTeam(owner) == GetClientTeam(client) )
+			TF2_RemoveWearable(owner, entity);
+
+	while( (entity = FindEntityByClassname(entity, "tf_powerup_bottle")) != -1 )
+		if( (owner = GetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity")) <= MaxClients && owner > 0 && GetClientTeam(owner) == GetClientTeam(client) )
+			TF2_RemoveWearable(owner, entity);
+}
+
+
+/* Trade Spam */
+void Rage_Trade_Spam(const FF2Player player)
+{
+	CreateTimer(0.1, Trade_KeepSpamming, 1, TIMER_FLAG_NO_MAPCHANGE);
+}
+
+public Action Trade_KeepSpamming(Handle timer, int count)
+{
+	if( count == 13 )  //Rage has finished-reset it in 6 seconds (trade_0 is 100% transparent apparently)
+		CreateTimer(6.0, Trade_KeepSpamming, 0, TIMER_FLAG_NO_MAPCHANGE);
+	else {
+		static char overlay[PLATFORM_MAX_PATH];
+		Format(overlay, sizeof(overlay), "r_screenoverlay \"freak_fortress_2/demopan/trade_%i\"", count);
+
+		SetCommandFlags("r_screenoverlay", GetCommandFlags("r_screenoverlay") & ~FCVAR_CHEAT);  //Allow normal players to use r_screenoverlay
+		for( int client = 1; client <= MaxClients; client++ ) {
+			if(IsClientInGame(client) && IsPlayerAlive(client) && GetClientTeam(client) != VSH2Team_Boss) {
+				ClientCommand(client, overlay);
+			}
+		}
+		SetCommandFlags("r_screenoverlay", GetCommandFlags("r_screenoverlay") & FCVAR_CHEAT);  //Reset the cheat permissions
+
+		if(count) {
+			EmitSoundToAll("ui/notification_alert.wav", .updatePos = false);
+			CreateTimer( count == 1 ? 1.0 : 0.5/float(count), 
+						 Trade_KeepSpamming, 
+					 	 count + 1, 
+						 TIMER_FLAG_NO_MAPCHANGE );  //Give a longer delay between the first and second overlay for "smoothness"
+		}
+		else return Plugin_Stop; //Stop the rage
+	}
+	return Plugin_Continue;
+}
+
+
+/* Matrix */
+void Rage_Matrix(const FF2Player player)
+{
+	float timescale = player.GetArgF(this_plugin_name, MATRIX_ABILITY, "timescale", 0.5);
+	float duration = player.GetArgF(this_plugin_name, MATRIX_ABILITY, "duration", 1.0) + 1.0;
+	
+	player.SetPropInt("bNotifySMAC_CVars", 1);
+	m_ConVars.host_timescale.FloatValue = 0.5;
+	
+	ma_data.timer = CreateTimer(duration * timescale, Timer_StopSlowMo, player, TIMER_FLAG_NO_MAPCHANGE);
+	UpdateCheatValue("1");
+
+	int client = player.index;
+	AttachParticle(client, "scout_dodge_blue", 75.0, .time = duration);
+	
+	if( timescale != 1.0 )
+		EmitSoundToAll(SOUND_SLOW_MO_START, .updatePos = false);
+	
+	SDKHook(client, SDKHook_PostThinkPost, Post_ClientSlowMoThink);
+}
+
+public Action Timer_StopSlowMo(Handle timer, FF2Player player)
+{
+	int client = player.index;
+	
+	ma_data.InValidate();
+	
+	float timescale = m_ConVars.host_timescale.FloatValue;
+	m_ConVars.host_timescale.FloatValue = 1.0;
+	
+	UpdateCheatValue("0");
+	
+	player.SetPropInt("bNotifySMAC_CVars", 0);
+	
+	if( timescale != 1.0 )
+		EmitSoundToAll(SOUND_SLOW_MO_END, .updatePos = false);
+	
+	if( client ) 
+		SDKUnhook(client, SDKHook_PostThinkPost, Post_ClientSlowMoThink);
+}
+
+public void Post_ClientSlowMoThink(int client)
+{
+	if( ff2_gm.RoundState != StateRunning ) {
+		SDKUnhook(client, SDKHook_PostThinkPost, Post_ClientSlowMoThink);
+		return;
+	}
+	static float flNextClick[MAXCLIENTS];
+	if( GetClientButtons(client) & IN_ATTACK && flNextClick[client] < GetGameTime() ) {
+		flNextClick[client] = GetGameTime() + FF2Player(client).GetArgF(this_plugin_name, MATRIX_ABILITY, "delay", 0.2);
+		
+		static float bossPosition[3], endPosition[3], vecbuffer[3];
+		GetClientEyePosition(client, bossPosition);
+		GetClientEyeAngles(client, vecbuffer);
+
+		Handle trace = TR_TraceRayFilterEx(bossPosition, vecbuffer, MASK_SOLID, RayType_Infinite, TraceRayDontHitSelf, EntIndexToEntRef(client));
+		TR_GetEndPosition(endPosition, trace);
+		endPosition[2] += 100;
+		
+		SubtractVectors(endPosition, bossPosition, vecbuffer);
+		NormalizeVector(vecbuffer, vecbuffer);
+		ScaleVector(vecbuffer, 2012.0);
+		TeleportEntity(client, NULL_VECTOR, NULL_VECTOR, vecbuffer);
+		
+		int target = TR_GetEntityIndex(trace);
+		if( target > 0 && target <= MaxClients ) {
+			DataPack pack;
+			CreateDataTimer(0.15, Timer_Rage_SlowMo_Attack, pack);
+			pack.WriteCell(GetClientUserId(client));
+			pack.WriteCell(GetClientUserId(target));
+			pack.Reset();
+		}
+		
+		delete trace;
+	}
+}
+
+public Action Timer_Rage_SlowMo_Attack(Handle timer, DataPack pack)
+{
+	int client = GetClientOfUserId(pack.ReadCell());
+	int target = GetClientOfUserId(pack.ReadCell());
+	if( client && 
+		target && 
+		IsClientInGame(client) && 
+		IsClientInGame(target) && 
+		GetClientTeam(client) != GetClientTeam(target)) {
+		
+		static float clientPosition[3], targetPosition[3];
+		GetEntPropVector(client, Prop_Send, "m_vecOrigin", clientPosition);
+		GetEntPropVector(target, Prop_Send, "m_vecOrigin", targetPosition);
+		
+		if( GetVectorDistance(clientPosition, targetPosition) <= 1500 && ma_data.Validate(target) ) {
+			SetEntProp(client, Prop_Send, "m_bDucked", 1);
+			SetEntityFlags(client, GetEntityFlags(client) | FL_DUCKING);
+			
+			SDKHooks_TakeDamage(target, client, client, 850.0);
+			TeleportEntity(client, targetPosition, NULL_VECTOR, NULL_VECTOR);
+		}
+	}
+}
+
+public bool TraceRayDontHitSelf(int entity, int mask, int ref)
+{
+	return EntIndexToEntRef(entity) != ref;
+}
+
+
+/* Overlay */
+void Rage_Overlay(const FF2Player player)
+{
+	static char overlay[PLATFORM_MAX_PATH];
+	if( !player.GetArgS(this_plugin_name, OVERLAY_ABILITY, "path", overlay, sizeof(overlay)) )
+		return;
+	
+	float duration = player.GetArgF(this_plugin_name, OVERLAY_ABILITY, "duration", 6.0);
+
+	Format(overlay, PLATFORM_MAX_PATH, "r_screenoverlay \"%s\"", overlay);
+	SetCommandFlags("r_screenoverlay", GetCommandFlags("r_screenoverlay") &~ FCVAR_CHEAT);
+	
+	for( int target = 1; target <= MaxClients; target++ )
+		if( IsClientInGame(target) && IsPlayerAlive(target) && GetClientTeam(target) != VSH2Team_Boss )
+			ClientCommand(target, overlay);
+
+	if( duration >= 0 )
+		CreateTimer(duration, Timer_Remove_Overlay, .flags = TIMER_FLAG_NO_MAPCHANGE);
+
+	SetCommandFlags("r_screenoverlay", GetCommandFlags("r_screenoverlay") & FCVAR_CHEAT);
+}
+
+public Action Timer_Remove_Overlay(Handle timer)
+{
+	SetCommandFlags("r_screenoverlay", GetCommandFlags("r_screenoverlay") & ~FCVAR_CHEAT);
+	
+	for( int target = 1; target <= MaxClients; target++ )
+		if( IsClientInGame(target) && IsPlayerAlive(target) && GetClientTeam(target) != VSH2Team_Boss )
+			ClientCommand(target, "r_screenoverlay off");
+	
+	SetCommandFlags("r_screenoverlay", GetCommandFlags("r_screenoverlay") & FCVAR_CHEAT);
+	return Plugin_Continue;
+}
+
+
+/* DemoCharge */
+public Action Do_DemoCharge(Handle timer, FF2Player player)
+{
+	int client = player.index;
+	float charge = player.GetPropFloat("flRAGE");
+	float res = charge - player.GetArgF(this_plugin_name, DEMOCHARGE_ABILITY, "rage", 2.0);
+	float flthink = player.GetArgF(this_plugin_name, DEMOCHARGE_ABILITY, "cooldown") / 2;
+	
+	if ( charge > player.GetArgF(this_plugin_name, DEMOCHARGE_ABILITY, "minimum", 10.0) &&
+	     charge <= player.GetArgF(this_plugin_name, DEMOCHARGE_ABILITY, "maximum", 100.0) && 
+	     res >= 0.0 ) {
+	     	
+		float duration = player.GetArgF(this_plugin_name, DEMOCHARGE_ABILITY, "duration", 0.25);
+		if( duration < 0 && duration != TFCondDuration_Infinite )
+			duration = TFCondDuration_Infinite;
+
+		SetEntPropFloat(client, Prop_Send, "m_flChargeMeter", 100.0);
+		TF2_AddCondition(client, TFCond_Charging, duration);
+		
+		player.SetPropFloat("flRAGE", res);
+		democharge.flNextThink[client] = GetGameTime() + flthink * 2;
+	} else democharge.flNextThink[client] = GetGameTime() + flthink;
+	
+	return Plugin_Continue;
+}
+
+
+/* No Anims */
+public Action Timer_Disable_Anims(Handle timer)
+{
+	for( int client = MaxClients; client > 0; client-- ) {
+		FF2Player player = FF2Player(client);
+		if(player.index && player.HasAbility(this_plugin_name, NO_ANIMS)) {
+			SetEntProp(client, Prop_Send, "m_bUseClassAnimations", player.GetArgF(this_plugin_name, NO_ANIMS, "custom model animation"));
+			SetEntProp(client, Prop_Send, "m_bCustomModelRotates", player.GetArgF(this_plugin_name, NO_ANIMS, "custom model rotates"));
+		}
+	}
+}
+
+
+/* Stocks */
+stock int AttachParticle(const int ent, const char[] particleType, float offset = 0.0, bool battach = true, float time = 3.0)
+{
+	int particle = CreateEntityByName("info_particle_system");
+	char tName[32];
+	float pos[3]; GetEntPropVector(ent, Prop_Send, "m_vecOrigin", pos);
+	pos[2] += offset;
+	TeleportEntity(particle, pos, NULL_VECTOR, NULL_VECTOR);
+	
+	FormatEx(tName, sizeof(tName), "target%i", ent);
+	
+	DispatchKeyValue(ent, "targetname", tName);
+	DispatchKeyValue(particle, "targetname", "tf2particle");
+	DispatchKeyValue(particle, "parentname", tName);
+	DispatchKeyValue(particle, "effect_name", particleType);
+	
+	DispatchSpawn(particle);
+	
+	SetVariantString(tName);
+	if( battach ) {
+		AcceptEntityInput(particle, "SetParent", particle, particle, 0);
+		SetEntPropEnt(particle, Prop_Send, "m_hOwnerEntity", ent);
+	}
+	
+	ActivateEntity(particle);
+	AcceptEntityInput(particle, "start");
+	CreateTimer(time, Timer_RemoveEntity, EntIndexToEntRef(particle));
+	
+	return particle;
+}
+
+public Action Timer_RemoveEntity(Handle timer, int ref)
+{
+	int ent = EntRefToEntIndex(ref);
+	if( IsValidEntity(ent) ) {
+		RemoveEntity(ent);
+	}
+}
+
+public Action Timer_EquipModel(Handle timer, DataPack pack)
+{
+	pack.Reset();
+	int client = ToFF2Player(pack).index;
+	if( IsClientInGame(client) && IsPlayerAlive(client) ) {
+		
+		static char model[PLATFORM_MAX_PATH];
+		pack.ReadString(model, sizeof(model));
+		
+		SetVariantString(model);
+		AcceptEntityInput(client, "SetCustomModel");
+		SetEntProp(client, Prop_Send, "m_bUseClassAnimations", 1);
+	}
+}
+
+void UpdateCheatValue(const char[] value)
+{
+	for( int client = MaxClients; client > 0; client-- ) {
+		if(IsClientInGame(client) && !IsFakeClient(client))
+			m_ConVars.sv_cheats.ReplicateToClient(client, value);
+	}
+}
+
+int SpawnManyObjects(const char[] classname, const int client, const char[] model, const int skin=0, const int amount=14, const float distance=30.0)
+{
+	if(!client || !IsClientInGame(client))
+		return;
+	
+	static int m_iPackType = 0;
+	if( !m_iPackType ) {
+		m_iPackType = FindSendPropInfo("CTFAmmoPack", "m_vecInitialVelocity") - 4;
+	}
+	
+	static float position[3], velocity[3];
+	GetClientAbsOrigin(client, position);
+	position[2] += distance;
+	
+	for( int i; i < amount; i++ ){
+		velocity[0] = GetRandomFloat(-400.0, 400.0);
+		velocity[1] = GetRandomFloat(-400.0, 400.0);
+		velocity[2] = GetRandomFloat(300.0, 500.0);
+		position[0] += GetRandomFloat(-5.0, 5.0);
+		position[1] += GetRandomFloat(-5.0, 5.0);
+
+		int entity = CreateEntityByName(classname);
+		if( !IsValidEntity(entity) ) {
+			FF2_ReportError(FF2Player(client), "[Boss] Invalid entity while spawning objects for %s-check your configs!", this_plugin_name);
+			break;
+		}
+
+		SetEntityModel(entity, model);
+		DispatchKeyValue(entity, "OnPlayerTouch", "!self,Kill,,0,-1");
+		
+		SetEntProp(entity, Prop_Send, "m_nSkin", skin);
+		SetEntProp(entity, Prop_Send, "m_nSolidType", 6);
+		SetEntProp(entity, Prop_Send, "m_usSolidFlags", 152);
+		SetEntProp(entity, Prop_Send, "m_triggerBloat", 24);
+		SetEntProp(entity, Prop_Send, "m_CollisionGroup", 1);
+		SetEntPropEnt(entity, Prop_Send, "m_hOwnerEntity", client);
+		
+		SetEntProp(entity, Prop_Send, "m_iTeamNum", 2);
+		DispatchSpawn(entity);
+		TeleportEntity(entity, position, view_as<float>({90.0, 0.0, 0.0}), velocity);
+		SetEntProp(entity, Prop_Data, "m_iHealth", 900);
+		
+		SetEntData(entity, m_iPackType, 1, .changeState = true);
+	}
+}
+
+public Action Timer_RemoveRagdoll(Handle timer, any userid)
+{
+	int client = GetClientOfUserId(userid);
+	int ragdoll;
+	if( client > 0 && (ragdoll = GetEntPropEnt(client, Prop_Send, "m_hRagdoll")) > MaxClients )
+		RemoveEntity(ragdoll);
+}
+
+public Action Timer_DissolveRagdoll(Handle timer, FF2Player player)
+{
+	int client = player.index;
+	int ragdoll = -1;
+	if( client && IsClientInGame(client) )
+		ragdoll = GetEntPropEnt(client, Prop_Send, "m_hRagdoll");
+
+	if(IsValidEntity(ragdoll)) {
+		int dissolver = CreateEntityByName("env_entity_dissolver");
+		if( dissolver != -1 ) {
+			DispatchKeyValue(dissolver, "dissolvetype", "0");
+			DispatchKeyValue(dissolver, "magnitude", "200");
+			DispatchKeyValue(dissolver, "target", "!activator");
+		
+			AcceptEntityInput(dissolver, "Dissolve", ragdoll);
+			RemoveEntity(dissolver);
+		}
+	}
+}
+
+
+void HandleAttackerKill(FF2Player victim, FF2Player player)
+{
+	if( player.HasAbility(this_plugin_name, OBJECTS_DEATH) ) {
+		static char model[PLATFORM_MAX_PATH], classname[PLATFORM_MAX_PATH];
+		if( player.GetArgS(this_plugin_name, OBJECTS_DEATH, "classname", classname, sizeof(classname)) &&
+			player.GetArgS(this_plugin_name, OBJECTS_DEATH, "model", model, sizeof(model)) )
+		
+		SpawnManyObjects(	classname, 
+							victim.index, 
+							model, 
+							player.GetArgI(this_plugin_name, OBJECTS_DEATH, "skin"), 
+							player.GetArgI(this_plugin_name, OBJECTS_DEATH, "amount", 14), 
+							player.GetArgF(this_plugin_name, OBJECTS_DEATH, "distance", 30.0) );
+	}
+	
+	if( player.HasAbility(this_plugin_name, DISSOLVE) ) {
+		CreateTimer(0.1, Timer_DissolveRagdoll, victim, TIMER_FLAG_NO_MAPCHANGE);
+	}
+	
+	if( player.HasAbility(this_plugin_name, CBS_MULTIMELEE) ) {
+		int attacker = player.index;
+		if( GetEntPropEnt(attacker, Prop_Send, "m_hActiveWeapon") == GetPlayerWeaponSlot(attacker, TFWeaponSlot_Melee) ) {
+			TF2_RemoveWeaponSlot(attacker, TFWeaponSlot_Melee);
+			static char attributes[128];
+			
+			if(!player.GetArgS(this_plugin_name, CBS_MULTIMELEE, "attributes", attributes, sizeof(attributes)))
+				attributes = "68 ; 2 ; 2 ; 3.1 ; 275 ; 1";
+			
+			int weapon;
+			switch( GetRandomInt(0, 2) ) {
+				case 0: weapon = player.SpawnWeapon("tf_weapon_club", 171, 101, 5, attributes);
+				case 1: weapon = player.SpawnWeapon("tf_weapon_club", 193, 101, 5, attributes);
+				case 2: weapon = player.SpawnWeapon("tf_weapon_club", 232, 101, 5, attributes);
+			}
+			
+			SetEntPropEnt(attacker, Prop_Data, "m_hActiveWeapon", weapon);
+		}
+	}
+	
+	if( player.HasAbility(this_plugin_name, DROP_PROP) )
+	{
+		static char model[PLATFORM_MAX_PATH];
+		if( player.GetArgS(this_plugin_name, DROP_PROP, "model", model, PLATFORM_MAX_PATH) ) {
+			if( !IsModelPrecached(model) ) {
+				if( !FileExists(model, true) ) {
+					FF2_ReportError(player, "[Boss] Model '%s' doesn't exist!, (plugin: %s - ability: %s)", model, this_plugin_name, DROP_PROP);
+					return;
+				} else PrecacheModel(model);
+			}
+			if( player.GetArgF(this_plugin_name, DROP_PROP, "remove ragdolls") )
+				CreateTimer(0.1, Timer_RemoveRagdoll, victim, TIMER_FLAG_NO_MAPCHANGE);
+			
+			int prop = CreateEntityByName("prop_physics_override");
+			if( prop != -1 ) {
+				SetEntityModel(prop, model);
+				SetEntityMoveType(prop, MOVETYPE_VPHYSICS);
+				SetEntProp(prop, Prop_Send, "m_CollisionGroup", 1);
+				SetEntProp(prop, Prop_Send, "m_usSolidFlags", 16);
+				DispatchSpawn(prop);
+				static float position[3];
+				GetEntPropVector(victim.index, Prop_Send, "m_vecOrigin", position);
+				position[2] += 20;
+				TeleportEntity(prop, position, NULL_VECTOR, NULL_VECTOR);
+				float duration = player.GetArgF(this_plugin_name, DROP_PROP, "duration");
+				if( duration > 0.5 )
+					CreateTimer(duration, Timer_RemoveEntity, EntIndexToEntRef(prop), TIMER_FLAG_NO_MAPCHANGE);
+			}
+		}
+	}
+}
+
+void HandleVictimKill(FF2Player player, int flags)
+{
+	if(	player.HasAbility(this_plugin_name, CLONE_ATK_ABILITY) && 
+		player.GetArgI(this_plugin_name, CLONE_ATK_ABILITY, "slay on death", 1) && 
+		!(flags & TF_DEATHFLAG_DEADRINGER))
+	{
+		FF2Player iter;
+		int client = player.index;
+		for( int i = 1; i <= MaxClients; i++ ) {
+			if( !IsClientInGame(i) || GetClientTeam(i) != GetClientTeam(client) )
+				continue;
+			iter = FF2Player(i);
+			if( iter.hOwnerBoss == player ) {
+				ChangeClientTeam(i, (GetClientTeam(client) == view_as<int>(TFTeam_Blue)) ? view_as<int>(TFTeam_Red) : view_as<int>(TFTeam_Blue));
+			}
+		}
+	}
+	
+	if( player.HasAbility(this_plugin_name, OBJECTS_DEATH) ) {
+		static char classname[PLATFORM_MAX_PATH], model[PLATFORM_MAX_PATH];
+		player.GetArgS(this_plugin_name, OBJECTS_DEATH, "classname", classname, PLATFORM_MAX_PATH);
+		player.GetArgS(this_plugin_name, OBJECTS_DEATH, "model", model, PLATFORM_MAX_PATH);
+		
+		SpawnManyObjects( classname, 
+						  player.index, 
+						  model, 
+						  player.GetArgI(this_plugin_name, OBJECTS_DEATH, "skin"), 
+						  player.GetArgI(this_plugin_name, OBJECTS_DEATH, "count", 14), 
+						  player.GetArgF(this_plugin_name, OBJECTS_DEATH, "distance", 30.0) );
+	}
+}

--- a/addons/sourcemod/scripting/include/freak_fortress_2.inc
+++ b/addons/sourcemod/scripting/include/freak_fortress_2.inc
@@ -1,0 +1,1253 @@
+#include <sdktools>
+#include <morecolors>
+#tryinclude <tf2items>
+
+#if defined _VSH2_FF2
+ #endinput
+#endif
+#define _VSH2_FF2
+
+#include <vsh2>
+
+
+enum FF2CallType_t
+{
+	CT_NONE			= 0b000000000,	// 	Inactive, default to CT_RAGE
+	CT_LIFE_LOSS 	= 0b000000001,	//	Life-loss
+	CT_RAGE		 	= 0b000000010,	//	generic E / taunt rage
+	CT_CHARGE		= 0b000000100,	//	charged and ready to super jump
+	CT_UNUSED_DEMO 	= 0b000001000,	//	UNUSED
+	CT_WEIGHDOWN	= 0b000010000,	//	
+	CT_PLAYER_KILLED= 0b000100000,
+	CT_BOSS_KILLED	= 0b001000000,
+	CT_BOSS_STABBED	= 0b010000000,
+	CT_BOSS_MG		= 0b100000000,
+};
+
+enum FF2RageType_t
+{
+	RT_RAGE = 0,
+	RT_WEIGHDOWN,
+	RT_CHARGE
+};
+
+#define INVALID_FF2PLAYER ToFF2Player(-1)
+#define ToFF2Player(%0)	view_as<FF2Player>(%0)
+#define FF2_PREFIX		"{olive}[FF2]{default} "
+
+/** 
+ * Some new properties:
+ *
+ * iLives
+ * iMaxLives
+ * bNoSuperJump
+ * bHideHUD
+ * bNotifySMAC_CVars
+ */
+methodmap FF2Player < VSH2Player {
+	/** [ C O N S T R U C T O R ]
+	 *
+	 * Constructs an instance of the BaseBoss internal methodmap
+	 *
+	 * @param index			index (or the userid) of a player
+	 * @param userid		if using userid instead of player index, set this param to true
+	 *
+	 * @return				a player instance of the FF2Player methodmap
+	 */
+	public native FF2Player(const int index, const bool userid = false);
+	
+	/**
+	 * list of abilities the current boss has
+	 *
+	 * @return				{ { "plugin_name##ability_name", "ability key" }, ... }
+	 */
+	property StringMap HookedAbilities {
+		public native get();
+	}
+	
+	property bool Valid {
+		public get() { return this != INVALID_FF2PLAYER && this.index; }
+	}
+	
+	/**
+	 * Retrieve an integer from boss config
+	 *
+	 * @param key_name		key name
+	 *
+	 * @return				true if key exists, false otherwise
+	 */
+	public native bool GetInt(const char[] key_name, int& res);
+	
+	/**
+	 * Retrieve a float value from boss config
+	 *
+	 * @param key_name		key name
+	 *
+	 * @return				true if key exists, false otherwise
+	 */
+	public native bool GetFloat(const char[] key_name, float& res);
+	
+	/**
+	 * Retrieve a string from boss config
+	 *
+	 * @param key_name		key name
+	 * @param res			output buffer
+	 * @param maxlen		size of output
+	 *
+	 * @return				number of bytes written, 0 if key doesn't exists
+	 */
+	public native int GetString(const char[] key_name, char[] res, int maxlen);
+	
+	/**
+	 * Retrieve an integer from boss ability
+	 *
+	 * @param pl_name		"plugin_name" instance
+	 * @param ab_name		ability "name" instance
+	 * @param key_name		key to extract
+	 * @param defVal		default value if no matching key was found
+	 *
+	 * @return				the value stored in ability
+	 */
+	public native int GetArgI(const char[] pl_name, const char[] ab_name, const char[] key_name, int defVal = 0);
+	
+	/**
+	 * Retrieve a float value from boss ability
+	 *
+	 * @param pl_name		"plugin_name" instance
+	 * @param ab_name		ability "name" instance
+	 * @param key_name		key to extract
+	 * @param defVal		default value if no matching key was found
+	 *
+	 * @return				the value stored in ability
+	 */
+	public native float GetArgF(const char[] pl_name, const char[] ab_name, const char[] key_name, float defVal = 0.0);
+	
+	/**
+	 * Retrieve a string from boss ability
+	 *
+	 * @param pl_name		"plugin_name" instance
+	 * @param ab_name		ability "name" instance
+	 * @param key_name		key to extract
+	 * @param buffer		buffer to store the value
+	 * @param maxlen		size of buffer
+	 *
+	 * @return				number of bytes written
+	 */
+	public native int GetArgS(const char[] pl_name, const char[] ab_name, const char[] key_name, char[] buffer, int maxlen);
+	
+	/**
+	 * Checks if a boss has this ability
+	 *
+	 * @param pl_name		"plugin_name" instance
+	 * @param ab_name		ability "name" instance
+	 *
+	 * @return				true on success, false otherwise
+	 */
+	public native bool HasAbility(const char[] pl_name, const char[] ab_name);
+	
+	/**
+	 * Gets an ability's rage distance
+	 *
+	 * @param pl_name		"plugin_name" instance
+	 * @param ab_name		ability "name" instance
+	 *
+	 * @return		Ability's rage distance
+	 */
+	public native float RageDist(const char[] pl_name = "", const char[] ab_name = "");
+	
+	/**
+	 * Starts the Boss's music for the specified client
+	 *
+	 * @param path	path for music to play
+	 *
+	 * @noreturn
+	 */
+	public native void PlayBGM(const char path[PLATFORM_MAX_PATH]);
+	
+	/**
+	 * Forces boss to use an ability
+	 *
+	 * @param boss		Boss's index
+	 * @param pluginName	Name of plugin with this ability
+	 * @param abilityName Name of ability
+	 * @param slot		check FF2CallType enums
+	 *
+	 * @note				this will NOT remove/reduce boss charge
+	 * @noreturn
+	 */
+	public native void DoAbility(const char[] pl_name, const char[] ab_name, FF2CallType_t slot);
+	
+	/**
+	 * Starts a random Boss sound from its config file
+	 *
+	 * @param keyvalue		Name of sound container
+	 * @param buffer		Buffer for result sound path
+	 * @param bufferLength	Length of buffer
+	 * @param boss			Boss's index
+	 *
+	 * @return		True if sound has been found, false otherwise
+	 */
+	public native bool RandomSound(const char[] key_name, char[] buffer, int maxlen);
+}
+
+
+/**
+ * Is Freak Fortress enabled?
+ *
+ * @return		False if FF2 is disabled
+ *			True if FF2 is enabled
+ */
+native bool FF2_IsFF2Enabled();
+
+
+methodmap FF2GameMode < VSH2GameMode
+{
+	public FF2GameMode() { return view_as< FF2GameMode >(0); }
+	
+	property bool FF2IsOn {
+		public get() { return FF2_IsFF2Enabled(); }
+	}
+	
+	property int RoundState {
+		public get() { return VSH2GameMode.GetPropInt("iRoundState"); }
+	}
+	
+	public static bool Validate(const VSH2Player player) {
+		return ToFF2Player(player).HookedAbilities != null;
+	}
+}
+
+
+/**
+ * Gets the version of FF2 running on the server
+ *
+ * @param version	An array of size 3 that will contain the major, minor, and stable version numbers respectively
+ *
+ * @return		
+ */
+native bool FF2_GetFF2Version(int[] version=0);
+
+/**
+ * Gets the version of the FF2 fork running on the server
+ *
+ * @note		Official FF2 versions always return 0 for version numbers
+ *
+ * @param version	An array of size 3 that will contain the major, minor, and stable version numbers respectively
+ *
+ * @return		
+ */
+native bool FF2_GetForkVersion(int[] fversion=0);
+
+/**
+ * Gets current round state
+ *
+ * @return		0 - in setup
+ *			1 - round is in progress (due to a bug in arena mode, stalemate will also return 1)
+ *			2 - someone wins
+ */
+stock int FF2_GetRoundState()
+{
+	return VSH2GameMode.GetPropInt("iRoundState");
+}
+
+/**
+ * Gets UserID of current Boss
+ * Redundant, use FF2Player if compiling for VSH2
+ *
+ * @param boss		Boss's index
+ *
+ * @return		Userid of boss (-1 if Boss does not exist)
+ */
+stock int FF2_GetBossUserId(int boss=0)
+{
+	FF2Player player = FF2Player(boss, true);
+	return player.userid;
+}
+
+/**
+ * Gets the boss index of a client
+ * Redundant, use FF2Player if compiling for VSH2
+ *
+ * @param client	The client used to search for the boss index
+ *
+ * @return		Boss index of that client.  If client is not boss, returns -1
+ */
+stock int FF2_GetBossIndex(int client)
+{
+	FF2Player player = FF2Player(client);
+	return player.userid;
+}
+
+/**
+ * Gets current team of Boss
+ *
+ * @return		boss' team index
+ */
+stock int FF2_GetBossTeam()
+{
+	return VSH2Team_Boss;
+}
+
+/**
+ * Gets the character name of the Boss
+ *
+ * @param boss	 		Boss's index
+ * @param buffer		Buffer for boss' character name
+ * @param bufferLength		Length of buffer string
+ * @param bossMeaning			0 - "boss" parameter means index of current Boss
+ *					1 - "boss" parameter means number of Boss in characters.cfg
+ *
+ * @return			True if boss exists, false if not
+ */
+native bool FF2_GetBossSpecial(int boss=0, char[] buffer, int bufferLength, int bossMeaning=0);
+
+/**
+ * Gets the current health value of the Boss
+ *
+ * @param boss		Boss's index
+ *
+ * @return		Current health of the Boss
+ */
+stock int FF2_GetBossHealth(int boss=0)
+{
+	FF2Player player = ToFF2Player(boss);
+	return player.GetPropInt("bIsBoss") ? player.GetPropInt("iHealth"):0;
+}
+
+/**
+ * Sets the health of the Boss
+ *
+ * @param boss		Boss's index
+ * @param health	New health value
+ *
+ * @noreturn
+ */
+stock void FF2_SetBossHealth(int boss, int health)
+{
+	FF2Player player = ToFF2Player(GetNativeCell(1));
+	if( player.SetPropInt("bIsBoss") ) {
+		player.SetPropInt("iHealth", health);
+	}
+}
+
+/**
+ * Gets the max health of the Boss
+ *
+ * @param boss		Boss's index
+ *
+ * @error		Invalid boss index
+ *
+ * @return		Max health of the Boss
+ */
+stock int FF2_GetBossMaxHealth(int boss=0)
+{
+	FF2Player player = ToFF2Player(boss);
+	return player.GetPropInt("bIsBoss") ? player.GetPropInt("iMaxHealth"):0;
+}
+
+/**
+ * Sets the max health of the Boss
+ *
+ * @param boss		Boss's index
+ * @param health	New max health value
+ *
+ * @noreturn
+ */
+stock void FF2_SetBossMaxHealth(int boss, int health)
+{
+	FF2Player player = ToFF2Player(GetNativeCell(1));
+	if( player.SetPropInt("bIsBoss") ) {
+		player.SetPropInt("iMaxHealth", health);
+	}
+}
+
+/**
+ * Gets the current number of lives of the Boss
+ *
+ * @param boss		Boss's index
+ *
+ * @return 		Number of lives the boss has remaining
+ */
+stock int FF2_GetBossLives(int boss)
+{
+	FF2Player player = ToFF2Player(GetNativeCell(1));
+	if( player.SetPropInt("bIsBoss") ) {
+		player.SetPropInt("iLives", health);
+	}
+}
+
+/**
+ * Sets the current number of lives of the Boss
+ *
+ * @param boss		Boss's index
+ * @param lives		New number of lives
+ *
+ * @noreturn
+ */
+stock void FF2_SetBossLives(int boss, int lives)
+{
+	FF2Player player = ToFF2Player(GetNativeCell(1));
+	if( player.SetPropInt("bIsBoss") ) {
+		player.SetPropInt("iLives", health);
+	}
+}
+
+/**
+ * Gets the max number of lives of the Boss
+ *
+ * @param boss		Boss's index
+ *
+ * @return		Max number of lives of the Boss
+ */
+stock int FF2_GetBossMaxLives(int boss)
+{
+	FF2Player player = ToFF2Player(GetNativeCell(1));
+	if( player.SetPropInt("bIsBoss") ) {
+		player.SetPropInt("iMaxLives", health);
+	}
+}
+
+/**
+ * Sets the max number of lives of the Boss
+ *
+ * @param boss		Boss's index
+ * @param lives		New max number of lives
+ *
+ * @noreturn
+ */
+stock void FF2_SetBossMaxLives(int boss, int lives)
+{
+	FF2Player player = ToFF2Player(GetNativeCell(1));
+	if( player.SetPropInt("bIsBoss") ) {
+		player.SetPropInt("iMaxLives", health);
+	}
+}
+
+/**
+ * Gets the charge meter value of the Boss
+ *
+ * @param boss		Boss's index
+ * @param slot		Slot of charge meter
+ *				0 - rage
+ *				1 - as usual, used for brave jump or teleport
+ *				2 - other charged abilities
+ *
+ * @return		Charge value of the Boss
+ */
+native float FF2_GetBossCharge(int boss, int slot);
+
+/**
+ * Sets the charge meter value of the Boss
+ *
+ * @param boss		Boss's index
+ * @param slot		Slot of charge meter
+ *				0 	- rage
+ *				1 	- as usual, used for brave jump or teleport
+ *				... - other charged abilities
+ * @param value		New value of charge
+ *
+ * @noreturn
+ */
+native void FF2_SetBossCharge(int boss, int slot, float value);
+
+/**
+ * Gets damage dealt by this client
+ *
+ * @param client 	Client's index
+ *
+ * @return		Damage dealt
+ */
+stock int FF2_GetClientDamage(int client)
+{
+	FF2Player player = FF2Player(GetNativeCell(1));
+	return player.GetPropInt("iDamage");
+}
+
+/**
+ * Gets damage dealt by this client
+ *
+ * @param client 	Client's index
+ *
+ * @noreturn
+ */
+stock void FF2_SetClientDamage(int client, int damage)
+{
+	FF2Player player = FF2Player(GetNativeCell(1));
+	player.SetPropInt("iDamage", damage);
+}
+
+/**
+ * Gets an ability's rage distance
+ *
+ * @param boss		Boss's index
+ * @param pluginName	Name of plugin with this ability
+ * @param abilityName	Name of ability (use null string if you want get boss's global "ragedist" value)
+ *
+ * @return		Ability's rage distance
+ */
+stock float FF2_GetRageDist(int boss=0, const char[] pluginName="", const char[] abilityName="")
+{
+	return FF2Player(boss).RageDist(plugin_name, ability_name);
+}
+
+/**
+ * Finds if a Boss has a certain ability
+ *
+ * @param boss		Boss's index
+ * @param pluginName	Name of plugin with this ability
+ * @param abilityName 	Name of ability
+ *
+ * @error		Invalid boss index
+ *
+ * @return		True if the boss has this ability, false if it doesn't
+ */
+stock bool FF2_HasAbility(int boss, const char[] pluginName, const char[] abilityName)
+{
+	return FF2Player(boss).HasAbility(pluginName, abilityName);
+}
+
+/**
+	 * Forces boss to use an ability
+	 *
+	 * @param boss		Boss's index
+	 * @param pluginName	Name of plugin with this ability
+	 * @param abilityName Name of ability
+	 * @param slot		check FF2CallType enums
+	 *
+	 * @note				this will NOT remove/reduce boss charge
+	 * @noreturn
+	 */
+stock void FF2_DoAbility(int boss, const char[] pluginName, const char[] abilityName, int slot)
+{
+	FF2Player(boss).DoAbility(pluginName, abilityName, view_as<FF2CallType_t>(slot));
+}
+
+/**
+ * Gets the integer value of an ability argument
+ *
+ * @param boss		Boss's index
+ * @param pluginName	Name of plugin with this ability
+ * @param abilityName 	Name of ability
+ * @param argument 	Number of argument
+ * @param defValue 	Returns if argument is not defined
+ *
+ * @return		Value of argument
+ */
+stock int FF2_GetAbilityArgument(int boss, const char[] pluginName, const char[] abilityName, int argument, int defValue=0)
+{
+	FF2Player player = FF2Player(boss);
+	static char arg_[8];
+	FormatEx(arg_, sizeof(arg_), "arg%i", argument);
+	return player.GetArgI(pluginName, abilityName, arg_, defValue);
+}
+
+/**
+ * Gets the float value of an ability argument
+ *
+ * @param boss		Boss's index
+ * @param pluginName	Name of plugin with this ability
+ * @param abilityName 	Name of ability
+ * @param argument 	Number of argument
+ * @param defValue 	Returns if argument is not defined
+ *
+ * @error		Invalid boss index
+ *
+ * @return		Value of argument
+ */
+stock float FF2_GetAbilityArgumentFloat(int boss, const char[] plugin_name, const char[] ability_name, int argument, float defValue=0.0)
+{
+	FF2Player player = FF2Player(boss);
+	static char arg_[8];
+	FormatEx(arg_, sizeof(arg_), "arg%i", argument);
+	return player.GetArgF(plugin_name, ability_name, arg_, defValue);
+}
+
+/**
+ * Gets the string value of an ability argument
+ *
+ * @param boss		Boss's index
+ * @param pluginName	Name of plugin with this ability
+ * @param abilityName 	Name of ability
+ * @param argument 	Number of argument
+ * @param buffer 	Buffer for value of argument
+ * @param bufferLength	Length of buffer string
+ *
+ * @error		Invalid boss index
+ *
+ * @noreturn
+ */
+stock void FF2_GetAbilityArgumentString(int boss, const char[] pluginName, const char[] abilityName, int argument, char[] buffer, int bufferLength)
+{
+	FF2Player player = FF2Player(boss);
+	static char arg_[8];
+	FormatEx(arg_, sizeof(arg_), "arg%i", argument);
+	player.GetArgS(pluginName, abilityName, arg_, buffer, bufferLength);
+}
+
+/**
+ * Gets the integer value of a named ability argument
+ *
+ * @param boss		Boss's index
+ * @param pluginName	Name of plugin with this ability
+ * @param abilityName 	Name of ability
+ * @param argument 	Argument name
+ * @param defValue 	Returns if argument is not defined
+ *
+ * @error		Invalid boss index
+ *
+ * @return		Value of argument
+ */
+stock int FF2_GetArgNamedI(int boss, const char[] pluginName, const char[] abilityName, const char[] argument, int defValue=0)
+{
+	FF2Player player = FF2Player(boss);
+	return player.GetArgS(pluginName, abilityName, argument, defValue);
+}
+
+/**
+ * Gets the float value of a named ability argument
+ *
+ * @param boss		Boss's index
+ * @param pluginName	Name of plugin with this ability
+ * @param abilityName 	Name of ability
+ * @param argument 	Argument name
+ * @param defValue 	Returns if argument is not defined
+ *
+ * @error		Invalid boss index
+ *
+ * @return		Value of argument
+ */
+stock float FF2_GetArgNamedF(int boss, const char[] plugin_name, const char[] ability_name, const char[] argument, float defValue=0.0)
+{
+	FF2Player player = FF2Player(boss);
+	return player.GetArgS(pluginName, abilityName, argument, defValue);
+}
+
+/**
+ * Gets the string value of a named ability argument
+ *
+ * @param boss		Boss's index
+ * @param pluginName	Name of plugin with this ability
+ * @param abilityName 	Name of ability
+ * @param argument 	Argument name
+ * @param buffer 	Buffer for value of argument
+ * @param bufferLength	Length of buffer string
+ *
+ * @noreturn
+ */
+stock void FF2_GetArgNamedS(int boss, const char[] pluginName, const char[] abilityName, const char[] argument, char[] buffer, int bufferLength)
+{
+	FF2Player player = FF2Player(boss);
+	player.GetArgS(pluginName, abilityName, argument, buffer, bufferLength);
+}
+
+/**
+ * Starts a random Boss sound from its config file
+ *
+ * @param keyvalue		Name of sound container
+ * @param buffer		Buffer for result sound path
+ * @param bufferLength	Length of buffer
+ * @param boss			Boss's index
+ * @unused slot 		Only for "sound_ability" - slot of ability
+ *
+ * @return		True if sound has been found, false otherwise
+ */
+stock bool FF2_RandomSound(const char[] keyvalue, char[] buffer, int bufferLength, int boss=0, int slot=0)
+{
+	return FF2Player(boss).RandomSound(keyvalue, buffer, bufferlength);
+}
+
+/**
+ * Starts the Boss's music for the specified clients
+ *
+ * @param client	Client's index (0 for all clients)
+ * @param bgm		music path
+ *
+ * @noreturn
+ */
+stock void FF2_StartMusic(int client = 0, const char[] bgm = "")
+{
+	if( !client ) {
+		for( int i = 1; i <= MaxClients; i++ ) {
+			if(IsClientInGame(i)) {
+				FF2Player(i).PlayBGM(bgm);
+			}
+		}
+	}
+	else {
+		FF2Player player = FF2Player(client);
+		if( player.index ) {
+			player.PlayBGM(bgm);
+		}
+	}
+}
+
+/**
+ * Stops the Boss's music for the specified clients
+ *
+ * @param client	Client's index (0 for all clients)
+ *
+ * @noreturn
+ */
+stock void FF2_StopMusic(int client=0)
+{
+	if( !client ) {
+		for( int i = 1; i <= MaxClients; i++ ) {
+			if(IsClientInGame(i)) {
+				FF2Player(i).StopMusic(; )
+			}
+		}
+	}
+	else {
+		FF2Player player = FF2Player(client);
+		if( player.index ) {
+			player.StopMusic();
+		}
+	}
+}
+
+/**
+ * Gets a Boss's KV handle
+ *
+ * @return 		null
+ */
+#pragma deprecated Use FF2Player methodmaps
+stock Handle FF2_GetSpecialKV(int boss, int specialIndex=0)
+{
+	return null;
+}
+
+/**
+ * Gets a client's flags for FF2
+ * UNUSED
+ *
+ * @param client	Client's index
+ *
+ * @return		Client's FF2 flags
+ */
+stock int FF2_GetFF2flags(int client)
+{
+	FF2Player player = FF2Player(client);
+	return player.GetPropInt("iFlags");
+}
+
+/**
+ * Sets a client's flags for FF2
+ * UNUSED
+ *
+ * @param client	Client's index
+ * @param flags		New flag values
+ *
+ * @noreturn
+ */
+stock void FF2_SetFF2flags(int client, int flags)
+{
+	FF2Player player = FF2Player(client);
+	player.SetPropInt("iFlags", flags);
+}
+
+/**
+ * Gets a client's queue points
+ *
+ * @param client	Client's index
+ *
+ * @error		Invalid client index
+ *
+ * @return		Client's queue points, -999 if client is not valid
+ */
+stock int FF2_GetQueuePoints(int client)
+{
+	FF2Player player = ToFF2Player(GetNativeCell(1));
+	return player.Valid ? player.GetPropInt("iQueue"):-999;
+}
+
+/**
+ * Sets a client's queue points
+ *
+ * @param client	Client's index
+ * @param value		New value of client's queue points
+ *
+ * @error		Invalid client index
+ *
+ * @noreturn
+ */
+stock void FF2_SetQueuePoints(int client, int value)
+{
+	FF2Player player = FF2Player(client);
+	if ( player.Valid ) {
+		player.SetPropInt("iQueue", value);
+	}
+}
+
+/**
+ * Gets a client's glow timer
+ *
+ * @param client	Client's index
+ *
+ * @return			Glow time
+ */
+stock float FF2_GetClientGlow(int client)
+{
+	FF2Player player = FF2Player(client);
+	if( !player.Valid )
+		return -1.0;
+	
+	if( !GetEntProp(player.index, Prop_Send, "m_bGlowEnabled") )
+		return -1.0;
+	
+	return (player.GetPropFloat("flGlowtime"));
+}
+
+/**
+ * Sets a client's glow timer
+ *
+ * @param client	Client's index
+ * @param time1		Number of seconds to add to the glow timer (can be negative)
+ * @param time2		New value of glow timer
+ *
+ * @noreturn
+ */
+stock void FF2_SetClientGlow(int client, float time1, float time2=-1.0)
+{
+	FF2Player player = FF2Player(client);
+	if( !player.Valid )
+		return;
+	
+	if( time2 > 0.0 )
+		player.SetPropFloat("flGlowtime", time2);
+	else {
+		player.SetPropFloat("flGlowtime", player.GetPropFloat("flGlowtime") + time1);
+	}
+}
+
+/**
+ * Reports an error to FF2's error log
+ *
+ * @param message	Message to error log
+ *
+ * @noreturn
+ */
+native void FF2_LogError(const char[] message, any ...);
+
+/**
+ * Reports an error to FF2's error log with boss name
+ *
+ * @param boss		Boss index
+ * @param message	Message to error log
+ *
+ * @noreturn
+ * @error 			failed to format
+ */
+native void FF2_ReportError(const FF2Player boss = INVALID_FF2PLAYER, const char[] message, any ...);
+
+/**
+ * Returns whether or not debug is enabled
+ *
+ * @return		True if enabled, false otherwise
+ */
+stock bool FF2_Debug()
+{
+#if defined DEBUG
+	return true;
+#else 
+	return false;
+#endif
+}
+
+/**
+ * Sets the cheat status to turn off logging and statistics
+ *
+ * @param status	Disable statistics if true
+ *
+ * @noreturn
+ */
+native void FF2_SetCheats(bool status=true);
+
+/**
+ * Returns whether or not FF2 cheat commands was in the round
+ *
+ * @return		True if used, false otherwise
+ */
+native bool FF2_GetCheats();
+
+/**
+ * Sets the boss selection of a client
+ *
+ * @param client	Client's index
+ * @param boss		Boss's name ("name" key)
+ * @param access	Allow the client to play that boss regardless of permission
+ *
+ * @return		True if the client normally has access to this boss, false otherwise
+ */
+native bool FF2_MakeBoss(int client, const char[] boss_name, bool call_event = true);
+
+/**
+ * Called when before a Boss uses an ability (see FF2CallType_t)
+ *
+ * @note		Use FF2_PreAbility with enabled=false ONLY to prevent FF2_OnAbility!
+ *
+ * @param boss	 		Boss's index
+ * @param pluginName	Name of plugin with this ability
+ * @param abilityName 	Name of ability
+ * @param calltype		reason for the call
+ * @param enabled		reason for the call
+ *
+ * @noreturn
+ */
+forward void FF2_PreAbility(const FF2Player player, const char[] pluginName, const char[] abilityName, FF2CallType_t calltype, bool &enabled);
+
+/**
+ * Called when a Boss uses an ability (see FF2CallType_t)
+ *
+ * @param boss	 		Boss's index
+ * @param pluginName	Name of plugin with this ability
+ * @param abilityName 	Name of ability
+ * @param calltype		reason for the call
+ *
+ * @noreturn
+ */
+forward void FF2_OnAbility(const FF2Player player, const char[] pluginName, const char[] abilityName, FF2CallType_t calltype);
+
+/**
+ * Called when a Boss gets hurt by environmental damage
+ *
+ * @param boss	 	Boss's index
+ * @param triggerHurt	Entity index of "trigger_hurt"
+ * @param damage 	Damage by "trigger_hurt".  Cutomizable.
+ *
+ * @return		Plugin_Stop will prevent forward, Plugin_Changed will change damage.
+ */
+forward Action FF2_OnTriggerHurt(int boss, int triggerHurt, float &damage);
+
+/**
+ * Called when a Boss's music begins
+ *
+ * @param path 		Path to music sound file
+ * @param time		Length of music
+ *
+ * @return		Plugin_Stop will prevent music, Plugin_Changed will change it.
+ */
+forward Action FF2_OnMusic(char[] path, float &time);
+
+/**
+ * Called when a Boss's music begins with name and artist
+ *
+ * @param path 		Path to music sound file
+ * @param time		Length of music
+ * @param name 		The music name
+ * @param artist 	The music artist
+ *
+ * @return		Plugin_Stop will prevent music, Plugin_Changed will change it.
+ */
+forward Action FF2_OnMusic2(char[] path, float &time, char[] name, char[] artist);
+
+/**
+ * Called when FF2 picks a character for a Boss
+ *
+ * @param boss		Boss index
+ * @param character   	Character index
+ * @param characterName	Character name
+ * @param preset	True if the boss was set using a command such as ff2_special
+ *
+ * @return		You can NOT use Plugin_Stop to prevent this, but you can change characterName and use Plugin_Changed to change the boss.  If you want to change 'character', then make 'characterName' null.
+ */
+forward Action FF2_OnBossSelected(FF2Player player, char[] characterName, bool preset);
+
+/**
+ * Called when FF2 adds queue points
+ *
+ * @param add_points	Array that contains each player's queue points
+ *
+ * @return		Plugin_Stop will prevent this, Plugin_Changed will change it.
+ */
+forward Action FF2_OnAddQueuePoints(int add_points[MAXPLAYERS+1]);
+
+/**
+ * Called when a Boss loses a life
+ *
+ * @param boss		Boss's index
+ * @param lives		Number of lives left
+ * @param maxLives	Max number of lives
+ *
+ * @return		Plugin_Stop or Plugin_Handled to prevent damage that would remove a life, Plugin_Changed if you want to change the number of lives left.
+ */
+forward Action FF2_OnLoseLife(int boss, int &lives, int maxLives);
+
+/**
+ * Called when the number of alive players changes.  Note that this will never be 0 as FF2 does not re-calculate the number of players once the round ends.
+ *
+ * @param players	Number of alive players left on the non-boss team
+ * @param bosses	Number of alive players left on the boss team (this includes minions as well)
+ *
+ * @noreturn
+ */
+//forward void FF2_OnAlivePlayersChanged(int players, int bosses);
+
+/**
+ * Called when a boss is backstabbed
+ *
+ * @param boss		Boss's index
+ * @param client	Boss's client index
+ * @param attacker	Attacker's client index
+ * @param damage	Damage dealt (includes crit bonus)
+ *
+ * @return		Plugin_Changed to adjust the damage dealt, Plugin_Handled to prevent damage being dealt but continue sounds, stuns, etc, Plugin_Stop to prevent the backstab all together
+ */
+forward Action FF2_OnBackStabbed(int boss, int client, int attacker);
+
+/**
+ * Gives ammo to a weapon
+ *
+ * @param client	Client's index
+ * @param weapon	Weapon
+ * @param ammo		Ammo (set to -1 for clipless weapons, then set the actual ammo using clip)
+ * @param clip		Clip
+ *
+ * @error		Invalid client index or client not in game
+ *
+ * @noreturn
+ */
+stock void FF2_SetAmmo(int client, int weapon, int ammo=-1, int clip=-1)
+{
+	if(IsValidEntity(weapon))
+	{
+		if(clip > -1)
+			SetEntProp(weapon, Prop_Data, "m_iClip1", clip);
+
+		int ammoType = (ammo>-1 ? GetEntProp(weapon, Prop_Send, "m_iPrimaryAmmoType") : -1);
+		if(ammoType != -1)
+			SetEntProp(client, Prop_Data, "m_iAmmo", ammo, _, ammoType);
+	}
+}
+
+/**
+ * Sends a synced HUD message according to FF2's rules
+ * Will only send if the client hasn't disabled their HUD and isn't checking the scoreboard
+ *
+ * Uses the same params and return values as ShowSyncHudText
+ */
+stock void FF2_ShowSyncHudText(int client, Handle sync, const char[] buffer, any ...)
+{
+	FF2Player player = FF2Player(client);
+	if( !player.GetPropInt("bHideHUD") && !(GetClientButtons(client) & IN_SCORE) ) {
+		char message[256];
+		VFormat(message, sizeof(message), buffer, 4);
+		SetGlobalTransTarget(client);
+		ShowSyncHudText(client, sync, message);
+	}
+}
+
+/**
+ * Sends a HUD message according to FF2's rules
+ * Will only send if the client hasn't disabled their HUD and isn't checking the scoreboard
+ *
+ * Uses the same params and return values as ShowHudText
+ */
+stock void FF2_ShowHudText(int client, int channel, const char[] buffer, any ...)
+{
+	if( !player.GetPropInt("bHideHUD") && !(GetClientButtons(client) & IN_SCORE) ) {
+		char message[256];
+		VFormat(message, sizeof(message), buffer, 4);
+		SetGlobalTransTarget(client);
+		ShowHudText(client, channel, message);
+	}
+}
+
+/**
+ * Used to consolidate debug messages
+ *
+ * @param buffer	Debug string to display
+ * @param ...		Formatting rules
+ *
+ * @noreturn
+ */
+stock void FF2Dbg(const char[] buffer, any ...)
+{
+	if( FF2_Debug() ) {
+		char message[192];
+		VFormat(message, sizeof(message), buffer, 2);
+		CPrintToChatAll("{olive}[FF2 {darkorange}DEBUG{olive}]{default} %s", message);
+		PrintToServer("[FF2 DEBUG] %s", message);
+	}
+}
+
+
+/**
+ * Prints a color message with FF2's prefix
+ *
+ * Uses the same params and return values as CPrintToChat, CPrintToChatAll, and CReplyToCommand
+ */
+stock void FPrintToChat(int client, const char[] message, any ...)
+{
+	SetGlobalTransTarget(client);
+	char buffer[192];
+	VFormat(buffer, sizeof(buffer), message, 3);
+	CPrintToChat(client, FF2_PREFIX ... "%s", buffer);
+}
+
+stock void FPrintToChatAll(const char[] message, any ...)
+{
+	char buffer[192];
+	VFormat(buffer, sizeof(buffer), message, 2);
+	CPrintToChatAll(FF2_PREFIX ... "%s", buffer);
+}
+
+stock void FReplyToCommand(int client, const char[] message, any ...)
+{
+	SetGlobalTransTarget(client);
+	char buffer[192];
+	VFormat(buffer, sizeof(buffer), message, 3);
+	if(!client)
+	{
+		CRemoveTags(buffer, sizeof(buffer));
+		PrintToServer("[FF2] %s", buffer);
+	}
+	else if(GetCmdReplySource() == SM_REPLY_TO_CONSOLE)
+	{
+		CRemoveTags(buffer, sizeof(buffer));
+		PrintToConsole(client, "[FF2] %s", buffer);
+	}
+	else
+	{
+		CPrintToChat(client, FF2_PREFIX ... "%s", buffer);
+	}
+}
+
+
+
+/**
+ * Used to spawn a weapon
+ *
+ * @param client	Client index
+ * @param name		Classname of the weapon
+ * @param index		Definition index of the weapon
+ * @param level		Level of the weapon
+ * @param qual		Quality of the weapon
+ * @param att		String, containing the attributes in the following format: attr ; val ; attr ; val ; ...
+ * @param visible	Weapon will be visible?
+ *
+ * @error		Invalid item index, level, quality, client index, or client not in game
+ *
+ * @return		Entity index of the weapon, -1 on failure
+ */
+stock int FF2_SpawnWeapon(int client, char[] name, int index, int level, int qual, const char[] att, bool visible=true)
+{
+	FF2Player player = FF2Player(client);
+	return player.SpawnWeapon(name, index, level, qual, att);
+}
+
+stock int FF2_GetBossPlayers()
+{
+	FF2Player[] bosses = new FF2Player[MaxClients];
+	return FF2GameMode.GetBosses(bosses);
+}
+
+
+
+public SharedPlugin __pl_FF2 =
+{
+	name = "freak_fortress_2",
+	file = "freak_fortress_2.smx",
+	#if defined REQUIRE_PLUGIN
+		required = 1,
+	#else
+		required = 0,
+	#endif
+};
+
+#if !defined REQUIRE_PLUGIN
+public void __pl_FF2_SetNTVOptional()
+{
+	#define MARK_OPTIONAL(%0) 		MarkNativeAsOptional(#%0)
+	#define MARK_OPTIONAL_M(%0) 	MarkNativeAsOptional("FF2Player."...#%0)
+	#define MARK_OPTIONAL_MGET(%0) 	MarkNativeAsOptional("FF2Player."...#%0...".get")
+	#define MARK_OPTIONAL_MSET(%0) 	MarkNativeAsOptional("FF2Player."...#%0...".set")
+	
+	MARK_OPTIONAL(FF2_IsFF2Enabled);
+	MARK_OPTIONAL(FF2_GetFF2Version);
+	MARK_OPTIONAL(FF2_GetForkVersion);
+	
+	MARK_OPTIONAL(FF2_GetBossSpecial);
+	
+	MARK_OPTIONAL(FF2_LogError);
+	MARK_OPTIONAL(FF2_Debug);
+	
+	MARK_OPTIONAL(FF2_GetCheats);
+	MARK_OPTIONAL(FF2_SetCheats);
+	
+	MARK_OPTIONAL(FF2_GetBossCharge);
+	MARK_OPTIONAL(FF2_SetBossCharge);
+	
+	MARK_OPTIONAL(FF2_GetBossPlayers);
+	MARK_OPTIONAL(FF2_MakeBoss);
+
+	MARK_OPTIONAL_M(FF2Player);
+	MARK_OPTIONAL_M(GetInt);
+	MARK_OPTIONAL_M(GetFloat);
+	MARK_OPTIONAL_M(GetString);
+	MARK_OPTIONAL_M(GetArgI);
+	MARK_OPTIONAL_M(GetArgF);
+	MARK_OPTIONAL_M(GetArgS);
+	
+	MARK_OPTIONAL_M(HasAbility);
+	MARK_OPTIONAL_M(DoAbility);
+	MARK_OPTIONAL_M(RandomSound);
+	MARK_OPTIONAL_M(RageDist);
+	
+	MARK_OPTIONAL_MGET(HookedAbilities);
+	MARK_OPTIONAL_M(PlayBGM);
+	
+	#undef MARK_OPTIONAL
+	#undef MARK_OPTIONAL_MGET
+	#undef MARK_OPTIONAL_MSET
+}
+#endif
+
+
+#if defined FF2_USING_AUTO_PLUGIN
+char this_plugin_name[64];
+
+static void GetThisPluginName()
+{
+	char pluginName[80];
+	GetPluginFilename(INVALID_HANDLE, pluginName, sizeof(pluginName));
+	ReplaceString(pluginName, sizeof(pluginName), ".ff2", "", false);
+	int forwardSlash = -1;
+	int backwardSlash = -1;
+	int finalPluginName = -1;
+	for(;;)
+	{
+		forwardSlash = StrContains(pluginName[finalPluginName+1], "/");
+		backwardSlash = StrContains(pluginName[finalPluginName+1], "\\");
+		if((backwardSlash<forwardSlash && backwardSlash!=-1) || forwardSlash==-1)
+		{
+			if(backwardSlash == -1)
+				break;
+
+			finalPluginName = backwardSlash;
+		}
+		else if((forwardSlash<backwardSlash && forwardSlash!=-1) || backwardSlash==-1)
+		{
+			if(forwardSlash == -1)
+				break;
+
+			finalPluginName = forwardSlash;
+		}
+	}
+	strcopy(this_plugin_name, sizeof(this_plugin_name), pluginName[finalPluginName+1]);
+}
+
+public void OnPluginStart()
+{
+	GetThisPluginName();
+	OnPluginStart2();
+}
+
+public void FF2_OnAbility(const FF2Player player, const char[] pluginName, const char[] abilityName, FF2CallType_t calltype)
+{
+	if( !strcmp(pluginName, this_plugin_name) ) {
+		FF2_OnAbility2(player, abilityName, calltype);
+	}
+}
+#endif
+
+#file "Freak Fortress 2 Include"

--- a/addons/sourcemod/scripting/include/freak_fortress_2.inc
+++ b/addons/sourcemod/scripting/include/freak_fortress_2.inc
@@ -12,12 +12,12 @@
 
 enum FF2CallType_t
 {
-	CT_NONE			= 0b000000000,	// 	Inactive, default to CT_RAGE
-	CT_LIFE_LOSS 	= 0b000000001,	//	Life-loss
-	CT_RAGE		 	= 0b000000010,	//	generic E / taunt rage
-	CT_CHARGE		= 0b000000100,	//	charged and ready to super jump
+	CT_NONE		= 0b000000000,	// 	Inactive, default to CT_RAGE
+	CT_LIFE_LOSS 	= 0b000000001,
+	CT_RAGE		= 0b000000010,
+	CT_CHARGE	= 0b000000100,
 	CT_UNUSED_DEMO 	= 0b000001000,	//	UNUSED
-	CT_WEIGHDOWN	= 0b000010000,	//	
+	CT_WEIGHDOWN	= 0b000010000,
 	CT_PLAYER_KILLED= 0b000100000,
 	CT_BOSS_KILLED	= 0b001000000,
 	CT_BOSS_STABBED	= 0b010000000,
@@ -1203,6 +1203,7 @@ public void __pl_FF2_SetNTVOptional()
 #endif
 
 
+
 #if defined FF2_USING_AUTO_PLUGIN
 char this_plugin_name[64];
 
@@ -1248,6 +1249,53 @@ public void FF2_OnAbility(const FF2Player player, const char[] pluginName, const
 		FF2_OnAbility2(player, abilityName, calltype);
 	}
 }
+
+#elseif defined FF2_USING_AUTO_PLUGIN__OLD
+char this_plugin_name[64];
+
+static void GetThisPluginName()
+{
+	char pluginName[80];
+	GetPluginFilename(INVALID_HANDLE, pluginName, sizeof(pluginName));
+	ReplaceString(pluginName, sizeof(pluginName), ".ff2", "", false);
+	int forwardSlash = -1;
+	int backwardSlash = -1;
+	int finalPluginName = -1;
+	for(;;)
+	{
+		forwardSlash = StrContains(pluginName[finalPluginName+1], "/");
+		backwardSlash = StrContains(pluginName[finalPluginName+1], "\\");
+		if((backwardSlash<forwardSlash && backwardSlash!=-1) || forwardSlash==-1)
+		{
+			if(backwardSlash == -1)
+				break;
+
+			finalPluginName = backwardSlash;
+		}
+		else if((forwardSlash<backwardSlash && forwardSlash!=-1) || backwardSlash==-1)
+		{
+			if(forwardSlash == -1)
+				break;
+
+			finalPluginName = forwardSlash;
+		}
+	}
+	strcopy(this_plugin_name, sizeof(this_plugin_name), pluginName[finalPluginName+1]);
+}
+
+public void OnPluginStart()
+{
+	GetThisPluginName();
+	OnPluginStart2();
+}
+
+public void FF2_OnAbility(const FF2Player player, const char[] pluginName, const char[] abilityName, FF2CallType_t calltype)
+{
+	if( !strcmp(pluginName, this_plugin_name) ) {
+		FF2_OnAbility2(player.userid, pluginName, abilityName, view_as<int>(calltype));
+	}
+}
+
 #endif
 
 #file "Freak Fortress 2 Include"

--- a/addons/sourcemod/scripting/include/freak_fortress_2.inc
+++ b/addons/sourcemod/scripting/include/freak_fortress_2.inc
@@ -33,23 +33,32 @@ enum FF2RageType_t
 
 #if defined FF2_USING_AUTO_PLUGIN__OLD
 
-#define FF2FLAG_UBERREADY			(1<<1)		//Used when medic says "I'm charged!"
-#define FF2FLAG_ISBUFFED			(1<<2)		//Used when soldier uses the Battalion's Backup
-#define FF2FLAG_CLASSTIMERDISABLED 		(1<<3)		//Used to prevent clients' timer
-#define FF2FLAG_HUDDISABLED			(1<<4)		//Used to prevent custom hud from clients' timer
-#define FF2FLAG_BOTRAGE				(1<<5)		//Used by bots to use Boss's rage
-#define FF2FLAG_TALKING				(1<<6)		//Used by Bosses with "sound_block_vo" to disable block for some lines
-#define FF2FLAG_ALLOWSPAWNINBOSSTEAM		(1<<7)		//Used to allow spawn players in Boss's team
-#define FF2FLAG_USEBOSSTIMER			(1<<8)		//Used to prevent Boss's timer
-#define FF2FLAG_USINGABILITY			(1<<9)		//Used to prevent Boss's hints about abilities buttons
-#define FF2FLAG_CLASSHELPED			(1<<10)
-#define FF2FLAG_HASONGIVED			(1<<11)
-#define FF2FLAG_CHANGECVAR			(1<<12)		//Used to prevent SMAC from kicking bosses who are using certain rages (NYI)
-#define FF2FLAG_ALLOW_HEALTH_PICKUPS		(1<<13)		//Used to prevent bosses from picking up health
-#define FF2FLAG_ALLOW_AMMO_PICKUPS		(1<<14)		//Used to prevent bosses from picking up ammo
-#define FF2FLAG_ROCKET_JUMPING			(1<<15)		//Used when a soldier is rocket jumping
-#define FF2FLAG_ALLOW_BOSS_WEARABLES		(1<<16)		//Used to allow boss having wearables (only for Official FF2)
-#define FF2FLAGS_SPAWN				~FF2FLAG_UBERREADY & ~FF2FLAG_ISBUFFED & ~FF2FLAG_TALKING & ~FF2FLAG_ALLOWSPAWNINBOSSTEAM & ~FF2FLAG_CHANGECVAR & ~FF2FLAG_ROCKET_JUMPING & FF2FLAG_USEBOSSTIMER & FF2FLAG_USINGABILITY
+enum {
+	FF2FLAG_UBERREADY 				= (1<<1),		//Used when medic says "I'm charged!"				
+	FF2FLAG_ISBUFFED 				= (1<<2),		//Used when soldier uses the Battalion's Backup	
+	FF2FLAG_CLASSTIMERDISABLED 		= (1<<3),		//Used to prevent clients' timer		
+	FF2FLAG_HUDDISABLED 			= (1<<4),		//Used to prevent custom hud from clients' timer	
+	FF2FLAG_BOTRAGE 				= (1<<5),		//Used by bots to use Boss's rage
+	FF2FLAG_TALKING 				= (1<<6),		//Used by Bosses with "sound_block_vo" to disable block for some lines			
+	FF2FLAG_ALLOWSPAWNINBOSSTEAM	= (1<<7),		//Used to allow spawn players in Boss's team			
+	FF2FLAG_USEBOSSTIMER 			= (1<<8),		//Used to prevent Boss's timer		
+	FF2FLAG_USINGABILITY 			= (1<<9),		//Used to prevent Boss's hints about abilities buttons	
+	FF2FLAG_CLASSHELPED 			= (1<<10),					
+	FF2FLAG_HASONGIVED 				= (1<<11),					
+	FF2FLAG_CHANGECVAR				= (1<<12),		//Used to prevent SMAC from kicking bosses who are using certain rages (NYI)		
+	FF2FLAG_ALLOW_HEALTH_PICKUPS	= (1<<13),		//Used to prevent bosses from picking up health
+	FF2FLAG_ALLOW_AMMO_PICKUPS		= (1<<14),		//Used to prevent bosses from picking up ammo		
+	FF2FLAG_ROCKET_JUMPING			= (1<<15),		//Used when a soldier is rocket jumping
+	FF2FLAG_ALLOW_BOSS_WEARABLES	= (1<<16),		//Used to allow boss having wearables (only for Official FF2)
+	FF2FLAGS_SPAWN 					= ~FF2FLAG_UBERREADY 
+									& ~FF2FLAG_ISBUFFED 
+									& ~FF2FLAG_TALKING 
+									& ~FF2FLAG_ALLOWSPAWNINBOSSTEAM 
+									& ~FF2FLAG_CHANGECVAR 
+									& ~FF2FLAG_ROCKET_JUMPING 
+									& FF2FLAG_USEBOSSTIMER 
+									& FF2FLAG_USINGABILITY,					
+}
 
 #endif
 
@@ -424,9 +433,10 @@ stock void FF2_SetBossLives(int boss, int lives)
 stock int FF2_GetBossMaxLives(int boss)
 {
 	FF2Player player = ToFF2Player(GetNativeCell(1));
-	if( player.SetPropInt("bIsBoss") ) {
-		player.SetPropInt("iMaxLives", health);
+	if( player.GetPropInt("bIsBoss") ) {
+		return player.GetPropInt("iMaxLives");
 	}
+	return 0;
 }
 
 /**
@@ -441,7 +451,7 @@ stock void FF2_SetBossMaxLives(int boss, int lives)
 {
 	FF2Player player = ToFF2Player(GetNativeCell(1));
 	if( player.SetPropInt("bIsBoss") ) {
-		player.SetPropInt("iMaxLives", health);
+		player.SetPropInt("iMaxLives", lives);
 	}
 }
 

--- a/addons/sourcemod/scripting/include/freak_fortress_2.inc
+++ b/addons/sourcemod/scripting/include/freak_fortress_2.inc
@@ -34,30 +34,30 @@ enum FF2RageType_t
 #if defined FF2_USING_AUTO_PLUGIN__OLD
 
 enum {
-	FF2FLAG_UBERREADY 				= (1<<1),		//Used when medic says "I'm charged!"				
-	FF2FLAG_ISBUFFED 				= (1<<2),		//Used when soldier uses the Battalion's Backup	
-	FF2FLAG_CLASSTIMERDISABLED 		= (1<<3),		//Used to prevent clients' timer		
-	FF2FLAG_HUDDISABLED 			= (1<<4),		//Used to prevent custom hud from clients' timer	
-	FF2FLAG_BOTRAGE 				= (1<<5),		//Used by bots to use Boss's rage
-	FF2FLAG_TALKING 				= (1<<6),		//Used by Bosses with "sound_block_vo" to disable block for some lines			
+	FF2FLAG_UBERREADY 		= (1<<1),		//Used when medic says "I'm charged!"				
+	FF2FLAG_ISBUFFED 		= (1<<2),		//Used when soldier uses the Battalion's Backup	
+	FF2FLAG_CLASSTIMERDISABLED 	= (1<<3),		//Used to prevent clients' timer		
+	FF2FLAG_HUDDISABLED 		= (1<<4),		//Used to prevent custom hud from clients' timer	
+	FF2FLAG_BOTRAGE 		= (1<<5),		//Used by bots to use Boss's rage
+	FF2FLAG_TALKING 		= (1<<6),		//Used by Bosses with "sound_block_vo" to disable block for some lines			
 	FF2FLAG_ALLOWSPAWNINBOSSTEAM	= (1<<7),		//Used to allow spawn players in Boss's team			
-	FF2FLAG_USEBOSSTIMER 			= (1<<8),		//Used to prevent Boss's timer		
-	FF2FLAG_USINGABILITY 			= (1<<9),		//Used to prevent Boss's hints about abilities buttons	
-	FF2FLAG_CLASSHELPED 			= (1<<10),					
-	FF2FLAG_HASONGIVED 				= (1<<11),					
-	FF2FLAG_CHANGECVAR				= (1<<12),		//Used to prevent SMAC from kicking bosses who are using certain rages (NYI)		
+	FF2FLAG_USEBOSSTIMER 		= (1<<8),		//Used to prevent Boss's timer		
+	FF2FLAG_USINGABILITY 		= (1<<9),		//Used to prevent Boss's hints about abilities buttons	
+	FF2FLAG_CLASSHELPED 		= (1<<10),					
+	FF2FLAG_HASONGIVED 		= (1<<11),					
+	FF2FLAG_CHANGECVAR		= (1<<12),		//Used to prevent SMAC from kicking bosses who are using certain rages (NYI)		
 	FF2FLAG_ALLOW_HEALTH_PICKUPS	= (1<<13),		//Used to prevent bosses from picking up health
-	FF2FLAG_ALLOW_AMMO_PICKUPS		= (1<<14),		//Used to prevent bosses from picking up ammo		
-	FF2FLAG_ROCKET_JUMPING			= (1<<15),		//Used when a soldier is rocket jumping
+	FF2FLAG_ALLOW_AMMO_PICKUPS	= (1<<14),		//Used to prevent bosses from picking up ammo		
+	FF2FLAG_ROCKET_JUMPING		= (1<<15),		//Used when a soldier is rocket jumping
 	FF2FLAG_ALLOW_BOSS_WEARABLES	= (1<<16),		//Used to allow boss having wearables (only for Official FF2)
-	FF2FLAGS_SPAWN 					= ~FF2FLAG_UBERREADY 
-									& ~FF2FLAG_ISBUFFED 
-									& ~FF2FLAG_TALKING 
-									& ~FF2FLAG_ALLOWSPAWNINBOSSTEAM 
-									& ~FF2FLAG_CHANGECVAR 
-									& ~FF2FLAG_ROCKET_JUMPING 
-									& FF2FLAG_USEBOSSTIMER 
-									& FF2FLAG_USINGABILITY,					
+	FF2FLAGS_SPAWN 			= ~FF2FLAG_UBERREADY 
+					& ~FF2FLAG_ISBUFFED 
+					& ~FF2FLAG_TALKING 
+					& ~FF2FLAG_ALLOWSPAWNINBOSSTEAM 
+					& ~FF2FLAG_CHANGECVAR 
+					& ~FF2FLAG_ROCKET_JUMPING 
+					& FF2FLAG_USEBOSSTIMER 
+					& FF2FLAG_USINGABILITY,					
 }
 
 #endif

--- a/addons/sourcemod/scripting/include/freak_fortress_2.inc
+++ b/addons/sourcemod/scripting/include/freak_fortress_2.inc
@@ -21,7 +21,7 @@ enum FF2CallType_t
 	CT_PLAYER_KILLED= 0b000100000,
 	CT_BOSS_KILLED	= 0b001000000,
 	CT_BOSS_STABBED	= 0b010000000,
-	CT_BOSS_MG		= 0b100000000,
+	CT_BOSS_MG	= 0b100000000,
 };
 
 enum FF2RageType_t
@@ -261,7 +261,7 @@ stock int FF2_GetRoundState()
 stock int FF2_GetBossUserId(int boss=0)
 {
 	FF2Player player = FF2Player(boss, true);
-	return player.userid;
+	return player.GetPropInt("bIsBoss") ? player.userid:-1;
 }
 
 /**
@@ -275,7 +275,7 @@ stock int FF2_GetBossUserId(int boss=0)
 stock int FF2_GetBossIndex(int client)
 {
 	FF2Player player = FF2Player(client);
-	return player.userid;
+	return player.GetPropInt("bIsBoss") ? player.userid:-1;
 }
 
 /**
@@ -1204,7 +1204,7 @@ public void __pl_FF2_SetNTVOptional()
 
 
 
-#if defined FF2_USING_AUTO_PLUGIN
+#if defined FF2_USING_AUTO_PLUGIN || defined FF2_USING_AUTO_PLUGIN__OLD
 char this_plugin_name[64];
 
 static void GetThisPluginName()
@@ -1243,6 +1243,7 @@ public void OnPluginStart()
 	OnPluginStart2();
 }
 
+#if defined FF2_USING_AUTO_PLUGIN
 public void FF2_OnAbility(const FF2Player player, const char[] pluginName, const char[] abilityName, FF2CallType_t calltype)
 {
 	if( !strcmp(pluginName, this_plugin_name) ) {
@@ -1250,44 +1251,7 @@ public void FF2_OnAbility(const FF2Player player, const char[] pluginName, const
 	}
 }
 
-#elseif defined FF2_USING_AUTO_PLUGIN__OLD
-char this_plugin_name[64];
-
-static void GetThisPluginName()
-{
-	char pluginName[80];
-	GetPluginFilename(INVALID_HANDLE, pluginName, sizeof(pluginName));
-	ReplaceString(pluginName, sizeof(pluginName), ".ff2", "", false);
-	int forwardSlash = -1;
-	int backwardSlash = -1;
-	int finalPluginName = -1;
-	for(;;)
-	{
-		forwardSlash = StrContains(pluginName[finalPluginName+1], "/");
-		backwardSlash = StrContains(pluginName[finalPluginName+1], "\\");
-		if((backwardSlash<forwardSlash && backwardSlash!=-1) || forwardSlash==-1)
-		{
-			if(backwardSlash == -1)
-				break;
-
-			finalPluginName = backwardSlash;
-		}
-		else if((forwardSlash<backwardSlash && forwardSlash!=-1) || backwardSlash==-1)
-		{
-			if(forwardSlash == -1)
-				break;
-
-			finalPluginName = forwardSlash;
-		}
-	}
-	strcopy(this_plugin_name, sizeof(this_plugin_name), pluginName[finalPluginName+1]);
-}
-
-public void OnPluginStart()
-{
-	GetThisPluginName();
-	OnPluginStart2();
-}
+#else 
 
 public void FF2_OnAbility(const FF2Player player, const char[] pluginName, const char[] abilityName, FF2CallType_t calltype)
 {
@@ -1296,6 +1260,7 @@ public void FF2_OnAbility(const FF2Player player, const char[] pluginName, const
 	}
 }
 
+#endif
 #endif
 
 #file "Freak Fortress 2 Include"

--- a/addons/sourcemod/scripting/include/freak_fortress_2.inc
+++ b/addons/sourcemod/scripting/include/freak_fortress_2.inc
@@ -31,6 +31,28 @@ enum FF2RageType_t
 	RT_CHARGE
 };
 
+#if defined FF2_USING_AUTO_PLUGIN__OLD
+
+#define FF2FLAG_UBERREADY			(1<<1)		//Used when medic says "I'm charged!"
+#define FF2FLAG_ISBUFFED			(1<<2)		//Used when soldier uses the Battalion's Backup
+#define FF2FLAG_CLASSTIMERDISABLED 		(1<<3)		//Used to prevent clients' timer
+#define FF2FLAG_HUDDISABLED			(1<<4)		//Used to prevent custom hud from clients' timer
+#define FF2FLAG_BOTRAGE				(1<<5)		//Used by bots to use Boss's rage
+#define FF2FLAG_TALKING				(1<<6)		//Used by Bosses with "sound_block_vo" to disable block for some lines
+#define FF2FLAG_ALLOWSPAWNINBOSSTEAM		(1<<7)		//Used to allow spawn players in Boss's team
+#define FF2FLAG_USEBOSSTIMER			(1<<8)		//Used to prevent Boss's timer
+#define FF2FLAG_USINGABILITY			(1<<9)		//Used to prevent Boss's hints about abilities buttons
+#define FF2FLAG_CLASSHELPED			(1<<10)
+#define FF2FLAG_HASONGIVED			(1<<11)
+#define FF2FLAG_CHANGECVAR			(1<<12)		//Used to prevent SMAC from kicking bosses who are using certain rages (NYI)
+#define FF2FLAG_ALLOW_HEALTH_PICKUPS		(1<<13)		//Used to prevent bosses from picking up health
+#define FF2FLAG_ALLOW_AMMO_PICKUPS		(1<<14)		//Used to prevent bosses from picking up ammo
+#define FF2FLAG_ROCKET_JUMPING			(1<<15)		//Used when a soldier is rocket jumping
+#define FF2FLAG_ALLOW_BOSS_WEARABLES		(1<<16)		//Used to allow boss having wearables (only for Official FF2)
+#define FF2FLAGS_SPAWN				~FF2FLAG_UBERREADY & ~FF2FLAG_ISBUFFED & ~FF2FLAG_TALKING & ~FF2FLAG_ALLOWSPAWNINBOSSTEAM & ~FF2FLAG_CHANGECVAR & ~FF2FLAG_ROCKET_JUMPING & FF2FLAG_USEBOSSTIMER & FF2FLAG_USINGABILITY
+
+#endif
+
 #define INVALID_FF2PLAYER ToFF2Player(-1)
 #define ToFF2Player(%0)	view_as<FF2Player>(%0)
 #define FF2_PREFIX		"{olive}[FF2]{default} "
@@ -487,7 +509,7 @@ stock void FF2_SetClientDamage(int client, int damage)
  */
 stock float FF2_GetRageDist(int boss=0, const char[] pluginName="", const char[] abilityName="")
 {
-	return FF2Player(boss).RageDist(plugin_name, ability_name);
+	return FF2Player(boss).RageDist(pluginName, abilityName);
 }
 
 /**
@@ -653,7 +675,7 @@ stock void FF2_GetArgNamedS(int boss, const char[] pluginName, const char[] abil
  */
 stock bool FF2_RandomSound(const char[] keyvalue, char[] buffer, int bufferLength, int boss=0, int slot=0)
 {
-	return FF2Player(boss).RandomSound(keyvalue, buffer, bufferlength);
+	return FF2Player(boss).RandomSound(keyvalue, buffer, bufferLength);
 }
 
 /**
@@ -718,7 +740,6 @@ stock Handle FF2_GetSpecialKV(int boss, int specialIndex=0)
 
 /**
  * Gets a client's flags for FF2
- * UNUSED
  *
  * @param client	Client's index
  *
@@ -726,13 +747,15 @@ stock Handle FF2_GetSpecialKV(int boss, int specialIndex=0)
  */
 stock int FF2_GetFF2flags(int client)
 {
+#if defined FF2_USING_AUTO_PLUGIN__OLD
+	#warning this doesn't return what you think it does, use FF2Player.GetProp[Int, Float, Any] instead. 
+#endif
 	FF2Player player = FF2Player(client);
 	return player.GetPropInt("iFlags");
 }
 
 /**
  * Sets a client's flags for FF2
- * UNUSED
  *
  * @param client	Client's index
  * @param flags		New flag values
@@ -741,6 +764,9 @@ stock int FF2_GetFF2flags(int client)
  */
 stock void FF2_SetFF2flags(int client, int flags)
 {
+#if defined FF2_USING_AUTO_PLUGIN__OLD
+	#warning this doesn't return what you think it does, use FF2Player.SetProp[Int, Float, Any] instead.
+#endif
 	FF2Player player = FF2Player(client);
 	player.SetPropInt("iFlags", flags);
 }

--- a/addons/sourcemod/scripting/modules/ff2/console.sp
+++ b/addons/sourcemod/scripting/modules/ff2/console.sp
@@ -1,0 +1,16 @@
+
+void InitConVars()
+{
+	/// ConVars subplugins depend on
+	CreateConVar("ff2_oldjump", "1", "Use old Saxton Hale jump equations", _, true, 0.0, true, 1.0);
+	CreateConVar("ff2_base_jumper_stun", "0", "Whether or not the Base Jumper should be disabled when a player gets stunned", _, true, 0.0, true, 1.0);
+	CreateConVar("ff2_solo_shame", "0", "Always insult the boss for solo raging", _, true, 0.0, true, 1.0);
+	
+	ff2.m_cvars.m_enabled = 	FindConVar("vsh2_enabled");
+	ff2.m_cvars.m_version = 	FindConVar("vsh2_version");
+	ff2.m_cvars.m_fljarate = 	FindConVar("vsh2_jarate_rage");
+	ff2.m_cvars.m_flairblast = 	FindConVar("vsh2_airblast_rage");
+	ff2.m_cvars.m_flmusicvol = 	FindConVar("vsh2_music_volume");
+	ff2.m_cvars.m_packname = 	CreateConVar("ff2_current", "Freak Fortress 2", "Freak Fortress 2 current boss pack name", FCVAR_NOTIFY);
+	
+}

--- a/addons/sourcemod/scripting/modules/ff2/formula_parser.sp
+++ b/addons/sourcemod/scripting/modules/ff2/formula_parser.sp
@@ -44,7 +44,6 @@ float ParseFormula(const char[] formula, const int players)
 	GetToken(ls, formula);
 	return ParseAddExpr(ls, formula, players + 0.0);
 }
-#pragma unused ParseFormula	///REMOVE ME
 
 float ParseAddExpr(LexState ls, const char[] formula, const float n)
 {
@@ -60,7 +59,6 @@ float ParseAddExpr(LexState ls, const char[] formula, const float n)
 	}
 	return val;
 }
-#pragma unused ParseAddExpr
 
 float ParseMulExpr(LexState ls, const char[] formula, const float n)
 {
@@ -76,7 +74,6 @@ float ParseMulExpr(LexState ls, const char[] formula, const float n)
 	}
 	return val;
 }
-#pragma unused ParseMulExpr
 
 float ParsePowExpr(LexState ls, const char[] formula, const float n)
 {
@@ -89,7 +86,6 @@ float ParsePowExpr(LexState ls, const char[] formula, const float n)
 	}
 	return val;
 }
-#pragma unused ParsePowExpr
 
 float ParseFactor(LexState ls, const char[] formula, const float n)
 {
@@ -126,11 +122,9 @@ float ParseFactor(LexState ls, const char[] formula, const float n)
 	}
 	return 0.0;
 }
-#pragma unused ParseFactor
 
 bool LexOctal(LexState ls, const char[] formula)
 {
-	int lit_flags = 0;
 	while( formula[ls.i] != 0 && (IsCharNumeric(formula[ls.i])) ) {
 		switch( formula[ls.i] ) {
 			case '0', '1', '2', '3', '4', '5', '6', '7': {
@@ -145,11 +139,9 @@ bool LexOctal(LexState ls, const char[] formula)
 	}
 	return true;
 }
-#pragma unused LexOctal
 
 bool LexHex(LexState ls, const char[] formula)
 {
-	int lit_flags = 0;
 	while( formula[ls.i] != 0 && (IsCharNumeric(formula[ls.i]) || IsCharAlpha(formula[ls.i])) ) {
 		switch( formula[ls.i] ) {
 			case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
@@ -166,7 +158,6 @@ bool LexHex(LexState ls, const char[] formula)
 	}
 	return true;
 }
-#pragma unused LexHex
 
 bool LexDec(LexState ls, const char[] formula)
 {
@@ -193,7 +184,6 @@ bool LexDec(LexState ls, const char[] formula)
 	}
 	return true;
 }
-#pragma unused LexDec
 
 void GetToken(LexState ls, const char[] formula)
 {
@@ -300,4 +290,3 @@ void GetToken(LexState ls, const char[] formula)
 		}
 	}
 }
-#pragma unused GetToken

--- a/addons/sourcemod/scripting/modules/ff2/natives.sp
+++ b/addons/sourcemod/scripting/modules/ff2/natives.sp
@@ -5,69 +5,20 @@ void InitNatives()
 	CREATE_NATIVE(FF2_IsFF2Enabled);
 	CREATE_NATIVE(FF2_GetFF2Version);
 	CREATE_NATIVE(FF2_GetForkVersion);
-	CREATE_NATIVE(FF2_GetRoundState);
-	
-	CREATE_NATIVE(FF2_GetBossUserId);
-	CREATE_NATIVE(FF2_GetBossIndex);
-	CREATE_NATIVE(FF2_GetBossTeam);
 	
 	CREATE_NATIVE(FF2_GetBossSpecial);
-	CREATE_NATIVE(FF2_GetBossKV);
-	CREATE_NATIVE(FF2_GetSpecialKV);
-	
-	CREATE_NATIVE(FF2_GetBossHealth);
-	CREATE_NATIVE(FF2_SetBossHealth);
-	CREATE_NATIVE(FF2_GetBossMaxHealth);
-	CREATE_NATIVE(FF2_SetBossMaxHealth);
-	CREATE_NATIVE(FF2_GetBossLives);
-	CREATE_NATIVE(FF2_SetBossLives);
-	CREATE_NATIVE(FF2_GetBossMaxLives);
-	CREATE_NATIVE(FF2_SetBossMaxLives);
-	
-	CREATE_NATIVE(FF2_SetQueuePoints);
-	CREATE_NATIVE(FF2_GetQueuePoints);
 	
 	CREATE_NATIVE(FF2_LogError);
-	CREATE_NATIVE(FF2_Debug);
+	CREATE_NATIVE(FF2_ReportError);
 	
 	CREATE_NATIVE(FF2_GetCheats);
 	CREATE_NATIVE(FF2_SetCheats);
 	
 	CREATE_NATIVE(FF2_GetBossCharge);
 	CREATE_NATIVE(FF2_SetBossCharge);
-	CREATE_NATIVE(FF2_GetBossRageDamage);
-	CREATE_NATIVE(FF2_SetBossRageDamage);
-	CREATE_NATIVE(FF2_GetClientDamage);
-	CREATE_NATIVE(FF2_SetClientDamage);
-	
-	CREATE_NATIVE(FF2_GetRageDist);
-	CREATE_NATIVE(FF2_HasAbility);
-	CREATE_NATIVE(FF2_DoAbility);
-	CREATE_NATIVE(FF2_GetAbilityArgument);
-	CREATE_NATIVE(FF2_GetAbilityArgumentFloat);
-	CREATE_NATIVE(FF2_GetAbilityArgumentString);
-	CREATE_NATIVE(FF2_GetArgNamedI);
-	CREATE_NATIVE(FF2_GetArgNamedF);
-	CREATE_NATIVE(FF2_GetArgNamedS);
-	
-	CREATE_NATIVE(FF2_RandomSound);
-	CREATE_NATIVE(FF2_StartMusic);
-	CREATE_NATIVE(FF2_StopMusic);
-	
-	
-	CREATE_NATIVE(FF2_GetFF2flags);
-	CREATE_NATIVE(FF2_SetFF2flags);
-	CREATE_NATIVE(FF2_GetClientGlow);
-	CREATE_NATIVE(FF2_SetClientGlow);
 	
 	CREATE_NATIVE(FF2_GetBossPlayers);
-	CREATE_NATIVE(FF2_GetClientShield);
-	CREATE_NATIVE(FF2_SetClientShield);
-	CREATE_NATIVE(FF2_RemoveClientShield);
-	
 	CREATE_NATIVE(FF2_MakeBoss);
-	CREATE_NATIVE(FF2_SelectBoss);
-	CREATE_NATIVE(FF2_GetSpecialConfig);
 	
 	#undef CREATE_NATIVE
 	#define CREATE_NATIVE(%0)		CreateNative("FF2Player."...#%0			, Native_FF2Player_%0		)
@@ -79,14 +30,17 @@ void InitNatives()
 	CREATE_NATIVE(GetArgI);
 	CREATE_NATIVE(GetArgF);
 	CREATE_NATIVE(GetArgS);
-	CREATE_NATIVE_GET(iCfg);
-	CREATE_NATIVE_GET(iMaxLives); 	CREATE_NATIVE_SET(iMaxLives);
-	CREATE_NATIVE_GET(iRageDmg); 	CREATE_NATIVE_SET(iRageDmg);
-	CREATE_NATIVE_GET(iShieldId); 	CREATE_NATIVE_SET(iShieldId);
-	CREATE_NATIVE_GET(flShieldHP); 	CREATE_NATIVE_SET(flShieldHP);
+	
+	CREATE_NATIVE(GetInt);
+	CREATE_NATIVE(GetString);
+	CREATE_NATIVE(GetFloat);
+	
+	CREATE_NATIVE(HasAbility);
+	CREATE_NATIVE(DoAbility);
+	CREATE_NATIVE(RandomSound);
+	CREATE_NATIVE(RageDist);
+	
 	CREATE_NATIVE_GET(HookedAbilities);
-	CREATE_NATIVE_GET(bNoSuperJump);CREATE_NATIVE_SET(bNoSuperJump);
-	CREATE_NATIVE_GET(bHideHUD); 	CREATE_NATIVE_SET(bHideHUD);
 	CREATE_NATIVE(PlayBGM);
 	
 	#undef CREATE_NATIVE
@@ -141,88 +95,131 @@ public any Native_FF2Player_GetArgS(Handle plugin, int numParams)
 	return written;
 }
 
-public any Native_FF2Player_iCfg_Get(Handle plugin, int numParams)
+public any Native_FF2Player_HasAbility(Handle plugin, int numParams)
 {
 	FF2Player player = ToFF2Player(GetNativeCell(1));
-	return player.iCfg;
+	char plugin_name[64]; GetNativeString(2, plugin_name, sizeof(plugin_name));
+	char ability_name[64]; GetNativeString(3, ability_name, sizeof(ability_name));
+	
+	bool result = JumpToAbility(player, plugin_name, ability_name) != null;
+	return result;
 }
 
-public any Native_FF2Player_iMaxLives_Get(Handle plugin, int numParams)
+public any Native_FF2Player_DoAbility(Handle plugin, int numParams)
 {
 	FF2Player player = ToFF2Player(GetNativeCell(1));
-	return player.iMaxLives;
+	
+	char plugin_name[64]; GetNativeString(2, plugin_name, sizeof(plugin_name));
+	char ability_name[64]; GetNativeString(3, ability_name, sizeof(ability_name));
+	
+	int slot = GetNativeCell(4);
+	
+	Call_StartForward(ff2.m_forwards[FF2OnAbility]);
+	Call_PushCell(player);
+	Call_PushString(plugin_name);
+	Call_PushString(ability_name);
+	Call_PushCell(slot);
+	Call_Finish();
 }
 
-public any Native_FF2Player_iMaxLives_Set(Handle plugin, int numParams)
+public any Native_FF2Player_RandomSound(Handle plugin, int numParams)
 {
-	FF2Player player = ToFF2Player(GetNativeCell(1));
-	return player.iMaxLives;
+	FF2Player player = ToFF2Player(GetNativeCell(4));
+	
+	int size = GetNativeCell(3) + 1;
+	
+	int key_size; GetNativeStringLength(1, key_size); ++key_size;
+
+	char[] key = new char[key_size];
+	GetNativeString(1, key, key_size);
+
+	static FF2Identity identity;
+	if ( !ff2_cfgmgr.FindIdentity(player.GetPropInt("iBossType"), identity) )
+		return 0;
+	
+	bool soundExists;
+	
+	FF2SoundIdentity snd_id;
+	FF2SoundList list = identity.sndHash.GetList(key);
+	
+	if ( list ) {
+		soundExists = list.RandomSound(snd_id);
+	}
+	if ( !soundExists ) return false;
+	return SetNativeString(2, snd_id.path, size) == SP_ERROR_NONE;
 }
 
-public any Native_FF2Player_iRageDmg_Get(Handle plugin, int numParams)
+public any Native_FF2Player_RageDist(Handle plugin, int numParams)
 {
 	FF2Player player = ToFF2Player(GetNativeCell(1));
-	return player.iMaxLives;
+	if( !player.Valid )
+		return 0.0;
+	
+	char plugin_name[64]; GetNativeString(2, plugin_name, sizeof(plugin_name));
+	char ability_name[64]; GetNativeString(3, ability_name, sizeof(ability_name));
+	
+	ConfigMap cfg = player.iCfg;
+	if( !ability_name[0] ) {
+		float f;
+		return( cfg.GetFloat("ragedist", f) > 0 ) ? f : 0.0;
+	}
+	
+	ConfigMap section = JumpToAbility(player, plugin_name, ability_name);
+	float see;
+	if ( !section ) return 0.0;
+	if( !section.GetFloat("dist", see) && !section.GetFloat("ragedist", see) ) {
+		cfg.GetFloat("ragedist", see);
+	}
+	
+	return see;
 }
 
-public any Native_FF2Player_iRageDmg_Set(Handle plugin, int numParams)
+public any Native_FF2Player_GetInt(Handle plugin, int numParams)
 {
 	FF2Player player = ToFF2Player(GetNativeCell(1));
-	return player.iRageDmg;
+	
+	char key_name[64]; GetNativeString(2, key_name, sizeof(key_name));
+	
+	int val;
+	if( player.iCfg.GetInt(key_name, val) ) {
+		SetNativeCellRef(3, val);
+		return true;
+	}
+	return false;
 }
 
-public any Native_FF2Player_iShieldId_Get(Handle plugin, int numParams)
+public any Native_FF2Player_GetFloat(Handle plugin, int numParams)
 {
 	FF2Player player = ToFF2Player(GetNativeCell(1));
-	return player.iShieldId;
+	
+	char key_name[64]; GetNativeString(2, key_name, sizeof(key_name));
+	
+	float val;
+	if( player.iCfg.GetFloat(key_name, val) ) {
+		SetNativeCellRef(3, val);
+		return true;
+	}
+	return false;
 }
 
-public any Native_FF2Player_iShieldId_Set(Handle plugin, int numParams)
+public any Native_FF2Player_GetString(Handle plugin, int numParams)
 {
 	FF2Player player = ToFF2Player(GetNativeCell(1));
-	player.iShieldId = GetNativeCell(2);
-}
-
-public any Native_FF2Player_flShieldHP_Get(Handle plugin, int numParams)
-{
-	FF2Player player = ToFF2Player(GetNativeCell(1));
-	return player.flShieldHP;
-}
-
-public any Native_FF2Player_flShieldHP_Set(Handle plugin, int numParams)
-{
-	FF2Player player = ToFF2Player(GetNativeCell(1));
-	player.flShieldHP = GetNativeCell(2);
+	
+	char key_name[64]; GetNativeString(2, key_name, sizeof(key_name));
+	
+	int len = GetNativeCell(4);
+	char[] res = new char[len];
+	if( player.iCfg.Get(key_name, res, len) ) {
+		return SetNativeString(3, res, len);
+	}
+	return 0;
 }
 
 public any Native_FF2Player_HookedAbilities_Get(Handle plugin, int numParams)
 {
 	FF2Player player = ToFF2Player(GetNativeCell(1));
 	return player.HookedAbilities;
-}
-
-public any Native_FF2Player_bNoSuperJump_Get(Handle plugin, int numParams)
-{
-	FF2Player player = ToFF2Player(GetNativeCell(1));
-	return player.bNoSuperJump;
-}
-
-public any Native_FF2Player_bNoSuperJump_Set(Handle plugin, int numParams)
-{
-	FF2Player player = ToFF2Player(GetNativeCell(1));
-	player.bNoSuperJump = GetNativeCell(2);
-}
-
-public any Native_FF2Player_bHideHUD_Get(Handle plugin, int numParams)
-{
-	FF2Player player = ToFF2Player(GetNativeCell(1));
-	return player.bHideHUD;
-}
-
-public any Native_FF2Player_bHideHUD_Set(Handle plugin, int numParams)
-{
-	FF2Player player = ToFF2Player(GetNativeCell(1));
-	player.bHideHUD = GetNativeCell(2);
 }
 
 public any Native_FF2Player_PlayBGM(Handle plugin, int numParams)
@@ -239,14 +236,14 @@ public any Native_FF2Player_PlayBGM(Handle plugin, int numParams)
 /** bool FF2_IsFF2Enabled(); */
 public int Native_FF2_IsFF2Enabled(Handle plugin, int numParams)
 {
-	return vsh2cvars.m_enabled.BoolValue;
+	return ff2.m_cvars.m_enabled.BoolValue;
 }
 
 /** bool FF2_GetFF2Version(int[] version=0); */
 public int Native_FF2_GetFF2Version(Handle plugin, int numParams)
 {
 	char version_str[10];
-	vsh2cvars.m_version.GetString(version_str, sizeof(version_str));
+	ff2.m_cvars.m_version.GetString(version_str, sizeof(version_str));
 	
 	char digit[3][10];
 	int version_ints[3];
@@ -265,143 +262,33 @@ public int Native_FF2_GetForkVersion(Handle plugin, int numParams)
 	return 1;
 }
 
-/** int FF2_GetRoundState(); */
-public int Native_FF2_GetRoundState(Handle plugin, int numParams)
-{
-	return VSH2GameMode.GetPropInt("iRoundState");
-}
-
-/** int FF2_GetBossUserId(int boss=0); */
-public int Native_FF2_GetBossUserId(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	return ( player.Valid && player.GetPropInt("bIsBoss") ? player.userid:-1 );
-}
-
-/** int FF2_GetBossIndex(int client); */
-public any Native_FF2_GetBossIndex(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	return ( player.Valid && player.GetPropInt("bIsBoss") ? player.index:-1 );
-}
-
-/** int FF2_GetBossTeam(); */
-public int Native_FF2_GetBossTeam(Handle plugin, int numParams)
-{
-	return VSH2Team_Boss;
-}
-
 /** bool FF2_GetBossSpecial(int boss=0, char[] buffer, int bufferLength, int bossMeaning=0); */
 public int Native_FF2_GetBossSpecial(Handle plugin, int numParams)
 {
-	int
-		index = GetNativeCell(1),
+	int index = GetNativeCell(1),
 		buflen = GetNativeCell(3),
-		meaning = GetNativeCell(4)
-	;
+		meaning = GetNativeCell(4);
 	
-	FF2Player player = FF2Player(index);
-	if ( !player.Valid || !player.GetPropAny("bIsBoss") ) {
+	FF2Player player = ToFF2Player(index);
+	
+	FF2Identity id;
+	if( !ff2_cfgmgr.FindIdentity(player.iBossType, id) )
 		return false;
-	}
 	
 	char[] name = new char[buflen];
-	
 	if ( !meaning ) {
-		ConfigMap cfg = player.iCfg;
+		ConfigMap cfg = id.hCfg;
 		if( cfg ) {
-			if( cfg.Get("name", name, buflen) ) {
+			if( cfg.Get("character.name", name, buflen) ) {
 				SetNativeString(2, name, buflen);
 				return true;
 			}
 		}
-		
 		return false;
 	} else {
-		/// TODO
-		return false;
+		SetNativeString(2, id.szName, sizeof(FF2Identity::szName));
+		return true;
 	}
-}
-
-/** int FF2_GetBossHealth(int boss=0); */
-public int Native_FF2_GetBossHealth(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	return player.Valid && player.GetPropAny("bIsBoss") ? player.iHealth : 0;
-}
-
-/** bool FF2_SetBossHealth(int boss, int health); */
-public any Native_FF2_SetBossHealth(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	int new_health = GetNativeCell(2);
-	return player.Valid && player.GetPropAny("bIsBoss") ? player.SetPropInt("iHealth", new_health):false;
-}
-
-/** int FF2_GetBossMaxHealth(int boss=0); */
-public int Native_FF2_GetBossMaxHealth(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	return player.Valid && player.GetPropAny("bIsBoss") ? player.GetPropInt("iMaxHealth"):0;
-}
-
-/** void FF2_SetBossMaxHealth(int boss, int health); */
-public any Native_FF2_SetBossMaxHealth(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	int new_maxhealth = GetNativeCell(2);
-	return player.Valid && player.GetPropAny("bIsBoss") ? player.SetPropInt("iMaxHealth", new_maxhealth) : false;
-}
-
-/** int FF2_GetBossLives(int boss); */
-public any Native_FF2_GetBossLives(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	return player.Valid && player.GetPropAny("bIsBoss") ? player.GetPropInt("iLives") : 0;
-}
-
-/** void FF2_SetBossLives(int boss, int lives); */
-public any Native_FF2_SetBossLives(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	int lives = GetNativeCell(2);
-	player.SetPropInt("iLives", lives);
-}
-
-/** int FF2_GetBossMaxLives(int boss); */
-public any Native_FF2_GetBossMaxLives(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	return player.Valid && player.GetPropAny("bIsBoss") ? player.GetPropInt("iMaxLives") : 0;
-}
-
-/** void FF2_SetBossMaxLives(int boss, int lives); */
-public any Native_FF2_SetBossMaxLives(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	int lives = GetNativeCell(2);
-	player.SetPropInt("iMaxLives", lives);
-}
-
-/** bool FF2_SetQueuePoints(int client, int value); */
-public any Native_FF2_SetQueuePoints(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	if ( !player.Valid ) {
-		return false;
-	}
-	int q = GetNativeCell(2);
-	return player.SetPropInt("iQueue", q);
-}
-
-/** int FF2_GetQueuePoints(int client); */
-public any Native_FF2_GetQueuePoints(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	if ( !player.Valid ) {
-		return ThrowNativeError(SP_ERROR_NATIVE, "Invalid FF2Player index");
-	}
-	return player.GetPropInt("iQueue");
 }
 
 /** void FF2_LogError(const char[] message, any ...); */
@@ -417,10 +304,28 @@ public any Native_FF2_LogError(Handle plugin, int numParams)
 	return 0;
 }
 
-/** bool FF2_Debug(); */
-public any Native_FF2_Debug(Handle plugin, int numParams)
+/** void FF2_LogError(FF2Player player = INVALID_FF2_PLAYER, const char[] message, any ...); */
+public any Native_FF2_ReportError(Handle plugin, int numParams)
 {
-	return 1; /// Batfoxkid: Not sure what you want to do here, this mainly just tells the plugin when to print out Debug messages
+	FF2Player player = GetNativeCell(1);
+	char name[MAX_BOSS_NAME_SIZE] = "Unknown";
+	if( player.Valid ) {
+		if( player.GetName(name) ) {
+			name = "Unknown";
+		}
+	}
+	
+	LogError("[FF2] Exception reported: Boss: %i - Name: %s", player, name);
+	char actual[PLATFORM_MAX_PATH];
+	
+	int error;
+	if( (error = FormatNativeString(0, 2, 3, sizeof(actual), .out_string=actual)) != SP_ERROR_NONE )
+		return ThrowNativeError(error, "Failed to format");
+	
+	Format(actual, sizeof(actual), "[FF2] %s", actual);
+	LogError(actual);
+	
+	return 0;
 }
 
 /** void FF2_SetCheats(bool status); */
@@ -435,349 +340,29 @@ public any Native_FF2_GetCheats(Handle plugin, int numParams)
 	return ff2.m_cheats;
 }
 
-///	TODO
 /** float FF2_GetBossCharge(int boss, int slot); */
 public any Native_FF2_GetBossCharge(Handle plugin, int numParams)
 {
-	FF2Player player = FF2Player(GetNativeCell(1));
+	FF2Player player = ToFF2Player(GetNativeCell(1));
 	if( !player.Valid )
 		return 0.0;
 	
-	int slot = GetNativeCell(2);
-	switch( slot ) {
-		case 0: { /// Rage
-			return player.GetPropFloat("flRAGE");
-		}
-		default: {
-			return FF2_GetCustomCharge(player, slot);
-		}
-	}
+	FF2RageType_t slot = GetNativeCell(2);
+	return player.GetRageVar(slot);
 }
 
-///	TODO
 /** void FF2_SetBossCharge(int boss, int slot, float value); */
 public any Native_FF2_SetBossCharge(Handle plugin, int numParams)
 {
-	FF2Player player = FF2Player(GetNativeCell(1));
+	FF2Player player = ToFF2Player(GetNativeCell(1));
 	if( !player.Valid )
-		return 0.0;
+		return 0;
 	
-	int slot = GetNativeCell(2);
+	FF2RageType_t slot = GetNativeCell(2);
 	float value = GetNativeCell(3);
-	switch( slot ) {
-		case 0: { /// Rage
-			return player.SetPropFloat("flRAGE", value);
-		}
-		default: {
-			return FF2_SetCustomCharge(player, slot, value);
-		}
-	}
-}
-
-/** int FF2_GetBossRageDamage(int boss); */
-public int Native_FF2_GetBossRageDamage(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	return player.Valid ? player.iRageDmg:0;
-}
-
-/** void FF2_SetBossRageDamage(int boss, int damage); */
-public any Native_FF2_SetBossRageDamage(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	if (!player.Valid )
-		return false;
-	int damage = GetNativeCell(2);
-	player.iRageDmg = damage;
-	return true;
-}
-
-/** int FF2_GetClientDamage(int client); */
-public int Native_FF2_GetClientDamage(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	return player.Valid ? player.GetPropInt("iDamage"):0;
-}
-
-/** void FF2_SetClientDamage(int client, int val); */
-public int Native_FF2_SetClientDamage(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	return player.Valid ? player.SetPropInt("iDamage", GetNativeCell(2)):false;
-}
-
-/** float FF2_GetRageDist(int boss=0, const char[] pluginName="", const char[] abilityName=""); */
-public any Native_FF2_GetRageDist(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	if( !player.Valid )
-		return 0.0;
+	player.SetRageVar(slot, value);
 	
-	char plugin_name[64]; GetNativeString(2, plugin_name, sizeof(plugin_name));
-	char ability_name[64]; GetNativeString(3, ability_name, sizeof(ability_name));
-	
-	if( ability_name[0]==0 ) {
-		float f;
-		/// GetFloat + GetInt return number of characters used in conversion.
-		return( player.iCfg.GetFloat("ragedist", f) > 0 ) ? f : 0.0;
-	}
-	
-	ConfigMap section = JumpToAbility(player, plugin_name, ability_name);
-	float see;
-	if ( !section ) return 0.0;
-	if( !section.GetFloat("dist", see) ) {
-		section.GetFloat("ragedist", see);
-	}
-	
-	return see;
-}
-
-/** bool FF2_HasAbility(int boss, const char[] pluginName, const char[] abilityName); */
-public any Native_FF2_HasAbility(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	if( !player.Valid )
-		return false;
-	
-	char plugin_name[64]; GetNativeString(2, plugin_name, sizeof(plugin_name));
-	char ability_name[64]; GetNativeString(3, ability_name, sizeof(ability_name));
-	
-	bool result = JumpToAbility(player, plugin_name, ability_name) != null;
-	
-	return result;
-}
-
-/** bool FF2_DoAbility(int boss, const char[] pluginName, const char[] abilityName, int slot, int buttonMode=0); */
-public any Native_FF2_DoAbility(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	if( !player.Valid )
-		return ThrowNativeError(SP_ERROR_NATIVE, "[VSH2/FF2] Invalid boss index (%d) for FF2_DoAbility()!", player);
-	
-	char plugin_name[64]; GetNativeString(2, plugin_name, sizeof(plugin_name));
-	char ability_name[64]; GetNativeString(3, ability_name, sizeof(ability_name));
-	
-//	int slot = GetNativeCell(4);
-//	int button = GetNativeCell(5);
-	///TODO	
-//	Call_FF2OnAbility(player, plugin_name, ability_name, boss, slot, button);
-
-	return 0;
-}
-
-/** int FF2_GetAbilityArgument(int boss, const char[] pluginName, const char[] abilityName, int argument, int defValue=0); */
-public int Native_FF2_GetAbilityArgument(Handle plugin, int numParams)
-{
-	int boss = GetNativeCell(1);
-	
-	char plugin_name[64]; GetNativeString(2, plugin_name, sizeof(plugin_name));
-	char ability_name[64]; GetNativeString(3, ability_name, sizeof(ability_name));
-	char argument[8]; int key = GetNativeCell(4); FormatEx(argument, sizeof(argument), "arg%i", key);
-	
-	int defval = GetNativeCell(5);
-	
-	return GetArgNamedI(FF2Player(boss), plugin_name, ability_name, argument, defval);
-}
-
-/** float FF2_GetAbilityArgumentFloat(int boss, const char[] plugin_name, const char[] ability_name, int argument, float defValue=0.0); */
-public any Native_FF2_GetAbilityArgumentFloat(Handle plugin, int numParams)
-{
-	int boss = GetNativeCell(1);
-	
-	char plugin_name[64]; GetNativeString(2, plugin_name, sizeof(plugin_name));
-	char ability_name[64]; GetNativeString(3, ability_name, sizeof(ability_name));
-	char argument[8]; int key = GetNativeCell(4); FormatEx(argument, sizeof(argument), "arg%i", key);
-	
-	float defval = GetNativeCell(5);
-	
-	return GetArgNamedF(FF2Player(boss), plugin_name, ability_name, argument, defval);
-}
-
-/** void FF2_GetAbilityArgumentString(int boss, const char[] pluginName, const char[] abilityName, int argument, char[] buffer, int bufferLength); */
-public any Native_FF2_GetAbilityArgumentString(Handle plugin, int numParams)
-{
-	int boss = GetNativeCell(1);
-	
-	char plugin_name[64]; GetNativeString(2, plugin_name, sizeof(plugin_name));
-	char ability_name[64]; GetNativeString(3, ability_name, sizeof(ability_name));
-	char argument[8]; int key = GetNativeCell(4); FormatEx(argument, sizeof(argument), "arg%i", key);
-	int length; length = GetNativeCell(6);
-	char[] result = new char[length];
-	
-	int res = GetArgNamedS(FF2Player(boss), plugin_name, ability_name, argument, result, length);
-	if ( res )
-		SetNativeString(5, result, length);
-	
-	return res;
-}
-
-/** int FF2_GetArgNamedI(int boss, const char[] pluginName, const char[] abilityName, const char[] argument, int defValue=0); */
-public int Native_FF2_GetArgNamedI(Handle plugin, int numParams)
-{
-	int boss = GetNativeCell(1);
-	
-	char plugin_name[64]; GetNativeString(2, plugin_name, sizeof(plugin_name));
-	char ability_name[64]; GetNativeString(3, ability_name, sizeof(ability_name));
-	char argument[32]; GetNativeString(4, argument, sizeof(argument));
-	
-	int defval = GetNativeCell(5);
-	
-	return GetArgNamedI(FF2Player(boss), plugin_name, ability_name, argument, defval);
-}
-
-/** float FF2_GetArgNamedF(int boss, const char[] plugin_name, const char[] ability_name, const char[] argument, float defValue=0.0); */
-public any Native_FF2_GetArgNamedF(Handle plugin, int numParams)
-{
-	int boss = GetNativeCell(1);
-	
-	char plugin_name[64]; GetNativeString(2, plugin_name, sizeof(plugin_name));
-	char ability_name[64]; GetNativeString(3, ability_name, sizeof(ability_name));
-	char argument[32]; GetNativeString(4, argument, sizeof(argument));
-	
-	float defval = GetNativeCell(5);
-	
-	return GetArgNamedF(FF2Player(boss), plugin_name, ability_name, argument, defval);
-}
-
-/** void FF2_GetArgNamedS(int boss, const char[] pluginName, const char[] abilityName, const char[] argument, char[] buffer, int bufferLength); */
-public any Native_FF2_GetArgNamedS(Handle plugin, int numParams)
-{
-	int boss = GetNativeCell(1);
-	
-	char plugin_name[64]; GetNativeString(2, plugin_name, sizeof(plugin_name));
-	char ability_name[64]; GetNativeString(3, ability_name, sizeof(ability_name));
-	char argument[32]; GetNativeString(4, argument, sizeof(argument));
-	int length = GetNativeCell(6);
-	char[] result = new char[length];
-	
-	int res = GetArgNamedS(FF2Player(boss), plugin_name, ability_name, argument, result, length);
-	if ( res )
-		SetNativeString(5, result, length);
-	
-	return res;
-}
-
-/** bool FF2_RandomSound(const char[] keyvalue, char[] buffer, int bufferLength, int boss=0); */ /* int slot=0*/
-public any Native_FF2_RandomSound(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(4));
-	if( !player.Valid )
-		return ThrowNativeError(SP_ERROR_NATIVE, "[VSH2/FF2] Invalid boss index (%d) for FF2_DoAbility()!", player);
-	
-//	int slot = GetNativeCell(5);
-	int size = GetNativeCell(3) + 1;
-	
-	int key_size; GetNativeStringLength(1, key_size); ++key_size;
-
-	char[] key = new char[key_size];
-	GetNativeString(1, key, key_size);
-
-	static FF2Identity identity;
-	if ( !ff2_cfgmgr.FindIdentity(player.GetPropInt("iBossType"), identity) )
-		return 0;
-	
-	bool soundExists;
-	
-	FF2SoundIdentity snd_id;
-	FF2SoundList list = identity.sndHash.GetAssertedList(key);
-	
-	if ( list ) {
-		soundExists = list.RandomSound(snd_id);
-	}
-	if ( !soundExists ) return false;
-	return SetNativeString(2, snd_id.path, size) == SP_ERROR_NONE;
-}
-
-/** void FF2_StartMusic(int client=0); */
-public any Native_FF2_StartMusic(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	if( !player.Valid )
-		return 0;
-	player.PlayMusic(vsh2cvars.m_flmusicvol.FloatValue);
-	return 0;
-}
-
-/** void FF2_StopMusic(int client=0); */
-public any Native_FF2_StopMusic(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	if( !player.Valid )
-		return 0;
-	player.StopMusic();
-	return 0;
-}
-
-/** Handle FF2_GetBossKV(int boss=0); */
-public any Native_FF2_GetBossKV(Handle plugin, int numParams)
-{
-	/// Return null KV for now.
-	return 0;
-}
-
-/** Handle FF2_GetSpecialKV(int boss, int specialIndex=0); */
-public any Native_FF2_GetSpecialKV(Handle plugin, int numParams)
-{
-	/// Return null KV for now.
-	return 0;
-}
-
-/** int FF2_GetFF2flags(int client); */
-public int Native_FF2_GetFF2flags(Handle plugin, int numParams)
-{
-	return 0;
-	/*
-	FF2Player player = FF2Player(GetNativeCell(1));
-	if( !player.Valid )
-		return 0;
-	
-	return player.iFlags;
-	*/
-}
-
-/** void FF2_SetFF2flags(int client, int flags); */
-public any Native_FF2_SetFF2flags(Handle plugin, int numParams)
-{
-	return 0;
-	/*
-	FF2Player player = FF2Player(GetNativeCell(1));
-	if( !player.Valid )
-		return 0;
-	
-	int flags = GetNativeCell(2);
-	return player.iFlags = flags;
-	*/
-}
-
-/** float FF2_GetClientGlow(int client); */
-public any Native_FF2_GetClientGlow(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	if( !player.Valid )
-		return 0.0;
-	
-	if(!GetEntProp(player.index, Prop_Send, "m_bGlowEnabled"))
-		return 0.0;
-	
-	return (player.GetPropFloat("flGlowtime"));
-}
-
-/** void FF2_SetClientGlow(int client, float time1, float time2=-1.0); */
-public any Native_FF2_SetClientGlow(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	if( !player.Valid )
-		return 0;
-	
-	float time1 = GetNativeCell(2);
-	float time2 = GetNativeCell(3);
-	float glowt = player.GetPropFloat("flGlowtime");
-	player.SetPropFloat("flGlowtime", glowt + time1);
-	
-	if( time2 > 0.0 )
-		player.SetPropFloat("flGlowtime", time2);
-	
-	return 0;
+	return 1;
 }
 
 /** int FF2_GetAlivePlayers(); */
@@ -793,73 +378,21 @@ public any Native_FF2_GetBossPlayers(Handle plugin, int numParams)
 	return VSH2GameMode.GetBosses(bosses);
 }
 
-/** float FF2_GetClientShield(int client); */
-public any Native_FF2_GetClientShield(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	if( !player.Valid )
-		return 0;
-	
-	return (player.iShieldId == -1) ? -1:RoundFloat(player.flShieldHP);
-}
-
-/** void FF2_SetClientShield(int client, int entity=0, float health=0.0, float reduction=-1.0); */
-public any Native_FF2_SetClientShield(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	if( !player.Valid )
-		return false;
-	
-	int shield = GetNativeCell(2);
-	if( !IsValidEntity(shield) )
-		return false;
-		
-	float health = GetNativeCell(3);
-	
-	player.iShieldId = ( GetOwner(shield)!=player.index || shield==0 ) ? player.iShieldId : EntIndexToEntRef(shield);
-	player.flShieldHP = health;
-	
-	return true;
-}
-
-/** bool FF2_RemoveClientShield(int client); */
-public any Native_FF2_RemoveClientShield(Handle plugin, int numParams)
-{
-	FF2Player player = FF2Player(GetNativeCell(1));
-	if( !player.Valid )
-		return 0;
-	
-	player.flShieldHP = 0.0;
-	
-	int shield = TF2_GetWearable(player.index, TFWeaponSlot_Secondary);
-	if( shield == -1 || player.iShieldId == -1 )
-		return false;
-	
-	TF2_RemoveWearable(player.index, shield);
-	player.iShieldId = -1;
-	
-	return true;
-}
-
-/** TODO void FF2_MakeBoss(int client, int boss, int special=-1, bool rival=false); */
+/** void FF2_MakeBoss(int client, const char[] boss_name, bool call_event = true); */
 public any Native_FF2_MakeBoss(Handle plugin, int numParams)
 {
-	return 0;
-}
-
-/** TODO bool FF2_SelectBoss(int client, const char[] boss, bool access=true); */
-public any Native_FF2_SelectBoss(Handle plugin, int numParams)
-{
-	return 0;
-}
-
-/** ConfigMap FF2_GetSpecialConfig(int boss=0, bool meaning=false); */
-public any Native_FF2_GetSpecialConfig(Handle plugin, int numParams)
-{
-//	TODO
-//	int index = GetNativeCell(1);
-//	bool meaning = GetNativeCell(2);
-//	return GetFF2Config(index);
+	FF2Player player = FF2Player(GetNativeCell(1));
+	if( !player.Valid )
+		return false;
+	
+	char boss_name[48]; GetNativeString(2, boss_name, sizeof(boss_name));
+	FF2Identity id;
+	if( !ff2_cfgmgr.FindIdentityByName(boss_name, id) )
+		return false;
+	
+	player.MakeBossAndSwitch(id.VSH2ID, GetNativeCell(3));
+	
+	return true;
 }
 
 /** TODO ZZZZZZZZZZZZZZZZZZZZZZZZZZZ */
@@ -869,41 +402,3 @@ public any Native_ZZZ(Handle plugin, int numParams)
 	return 0;
 }
 */
-
-public Action Musics_Print(int client, int argc)
-{
-	FF2Identity id;
-	ff2_cfgmgr.GetIdentity("gentlespy", id);
-	
-	FF2SoundHash map = id.sndHash;
-	
-	StringMapSnapshot snap = map.Snapshot();
-	
-	char key[100];
-	FF2SoundList list;
-	FF2SoundIdentity cur;
-	int x;
-	for(; x < snap.Length; x++) 
-	{
-		snap.GetKey(x, key, sizeof(key));
-		list = map.GetAssertedList(key);
-		PrintToServer("[%i] = %s, HNDL: %x", x, key, list);
-		if(list) {
-			for(int j = 0; j < list.Length; j++)
-			{
-				if(list.At(j, cur)) {
-					PrintToServer("\t<||[%i]||> <%s> <%s> <%s> %.3f", j, cur.path, cur.name, cur.artist, cur.time);
-				}
-			}
-		}
-	}
-	
-	
-	delete snap;
-}
-
-void Reg_ConCmds()
-{
-	/// remove me
-	RegConsoleCmd("sm_print_musics", Musics_Print);
-}


### PR DESCRIPTION
I'm almost done, just need to finish life loss and do some checks incase there is a leak somewhere. oh and btw **ConfigMap** cannot be used outside of owner plugin **freak_fortress_2** since it stores **DataPacks**, therefore functions that relies on **KV** or **ConfigMap** iteration will find it difficult to do its job. My current solution is to just strip it and use **FF2Player.Get(Float, String, Int)** as a bridge, i don't think its reliable/good idea to clone the handle and copy everything from the original

abilities can be used as **"ability..."** instead of enumerating them
```
	"ability: Rage Instant Teleport"
	{
		"name"		"rage_instant_teleport"

		"stun"		"2.25"
		"flags"		"0x0061"
		"slowdown"	"0.5"
		"sound"		"0"
		"particle"	"ghost_smoke"
		
		"plugin_name"	"ff2_vsh2defaults"
	}
```

"mod_precache", "mat_download", "mod_download", "download" don't need to have a correct enumeration, except for sounds sections
**FF2_GetBossIndex** and **FF2_GetBossUserId** both return the same value, client userid which can help with backward compatibility
if you're compiling for old plugins, you must define **FF2_USING_AUTO_PLUGIN__OLD** else you can use **FF2_USING_AUTO_PLUGIN** which gives you "this_plugin_name" string, FF2_OnAbility2 and OnPluginStart2