### PR TITLE
Add Several Functions For ConfigMap

### DIFF
--- a/addons/sourcemod/scripting/include/cfgmap.inc
+++ b/addons/sourcemod/scripting/include/cfgmap.inc
@@ -644,7 +644,7 @@ static stock void ReplaceEscapeSeq(char[] str, int size)
 		{ "\n", "\\n" },
 		{ "\r", "\\r" }
 	};
-	for( int i; i<sizeof(list); i++) {
+	for( int i; i<sizeof(list); i++ ) {
 		ReplaceString(str, size, list[i][0], list[i][1]);
 	}
 }
@@ -657,7 +657,7 @@ static stock bool ConfigMapToFile(const ConfigMap cfg, const char[] sec_name, co
 	}
 	
 	char[] tab = new char[deep];
-	for( int i; i<deep; i++) tab[i]='\t';
+	for( int i; i<deep; i++ ) tab[i]='\t';
 	file.WriteLine("%s\"%s\" {", tab, sec_name);
 	
 	int size = snap.Length;

--- a/addons/sourcemod/scripting/include/cfgmap.inc
+++ b/addons/sourcemod/scripting/include/cfgmap.inc
@@ -118,8 +118,7 @@ methodmap ConfigMap < StringMap {
 		return view_as< ConfigMap >(cfg);
 	}
 	
-	public bool GetVal(const char[] key, PackVal valbuf)
-	{
+	public bool GetVal(const char[] key, PackVal valbuf) {
 		if( this==null ) {
 			return false;
 		}
@@ -127,10 +126,10 @@ methodmap ConfigMap < StringMap {
 		/// first check if we're getting a singular value OR we iterate through a sectional path.
 		int dot = FindCharInString(key, '.');
 		/// Patch: dot and escaped dot glitching out the hashmap hashing...
-		if( dot == -1 || (dot > 0 && key[dot-1] == '\\') ) {
+		if( dot==-1 || (dot > 0 && key[dot-1]=='\\') ) {
 			PackVal val;
 			bool result = this.GetArray(key, val, sizeof(val));
-			if( result && val.tag != KeyValType_Null ) {
+			if( result && val.tag!=KeyValType_Null ) {
 				valbuf = val;
 				return true;
 			}
@@ -169,6 +168,95 @@ methodmap ConfigMap < StringMap {
 				break;
 			} else if( StrEqual(curr_section, target_section) ) {
 				valbuf = val;
+				return true;
+			} else if( val.tag==KeyValType_Section ) {
+				val.data.Reset();
+				itermap = val.data.ReadCell();
+			}
+		}
+		return false;
+	}
+	
+	public bool SetVal(const char[] key, const char[] val_str = "", int val_size = 0) {
+		if( this==null ) {
+			return false;
+		}
+		///	if "do_erase" is set true, "SetVal" will behave as "RemoveVal", iterate and recursively delete the elements.
+		bool do_erase = val_size<0;
+		/// first check if we're getting a singular value OR we iterate through a sectional path.
+		int dot = FindCharInString(key, '.');
+		/// Patch: dot and escaped dot glitching out the hashmap hashing...
+		if( dot == -1 || (dot > 0 && key[dot-1] == '\\') ) {
+			PackVal val;
+			bool result = this.GetArray(key, val, sizeof(val));
+			KeyValType tag = val.tag;
+			if( result && tag!=KeyValType_Null ) {
+				if( do_erase ) {
+					if( val.tag==KeyValType_Section ) {
+						val.data.Reset();
+						ConfigMap cfg = val.data.ReadCell();
+						DeleteCfg(cfg);
+					}
+					delete val.data;
+					this.Remove(key);
+				}
+				else if( tag==KeyValType_Value ) {
+					val.data.Reset();
+					val.data.WriteString(val_str);
+					val.size = val_size;
+					this.SetArray(key, val, sizeof(val));
+				}
+				return true;
+			}
+			return false;
+		}
+		
+		/// ok, not a singular value, iterate to the specific linkmap section then.
+		/// parse the target key first.
+		int i; /// used for `key`.
+		char target_section[PLATFORM_MAX_PATH];
+		ParseTargetPath(key, target_section, sizeof(target_section));
+		
+		ConfigMap itermap = this;
+		while( itermap != null ) {
+			int n;
+			char curr_section[PLATFORM_MAX_PATH];
+			/// Patch: allow keys to use dot without interfering with dot path.
+			while( key[i] != 0 ) {
+				if( key[i]=='\\' && key[i+1] != 0 && key[i+1]=='.' ) {
+					i++;
+					if( n<PLATFORM_MAX_PATH ) {
+						curr_section[n++] = key[i++];
+					}
+				} else if( key[i]=='.' ) {
+					i++;
+					break;
+				} else {
+					if( n<PLATFORM_MAX_PATH ) {
+						curr_section[n++] = key[i++];
+					}
+				}
+			}
+			PackVal val;
+			bool result = itermap.GetArray(curr_section, val, sizeof(val));
+			if( !result ) {
+				break;
+			} else if( StrEqual(curr_section, target_section) ) {
+				if( !do_erase ) {
+					val.data.Reset();
+					val.data.WriteString(val_str);
+					val.size = val_size;
+					itermap.SetArray(curr_section, val, sizeof(val))	
+				}
+				else {
+					if( val.tag==KeyValType_Section ) {
+						val.data.Reset();
+						ConfigMap cfg = val.data.ReadCell();
+						DeleteCfg(cfg);
+					}
+					delete val.data;
+					itermap.Remove(curr_section);
+				}
 				return true;
 			} else if( val.tag==KeyValType_Section ) {
 				val.data.Reset();
@@ -356,16 +444,9 @@ methodmap ConfigMap < StringMap {
 		if( this==null ) {
 			return false;
 		}
-		PackVal val;
-		bool result = this.GetVal(key_path, val);
-		if( result && val.tag==KeyValType_Value ) {
-			val.data.Reset();
-			char val_str[15];
-			IntToString(i, val_str, sizeof(val_str));
-			val.data.WriteString(val_str);
-			return true;
-		}
-		return false;
+		char val_str[15];
+		int size = IntToString(i, val_str, sizeof(val_str)) + 1;
+		return this.SetVal(key_path, val_str, size);
 	}
 	
 	/**
@@ -381,16 +462,9 @@ methodmap ConfigMap < StringMap {
 		if( this==null ) {
 			return false;
 		}
-		PackVal val;
-		bool result = this.GetVal(key_path, val);
-		if( result && val.tag==KeyValType_Value ) {
-			val.data.Reset();
-			char val_str[15];
-			FloatToString(f, val_str, sizeof(val_str));
-			val.data.WriteString(val_str);
-			return true;
-		}
-		return false;
+		char val_str[15];
+		int size = FloatToString(f, val_str, sizeof(val_str)) + 1;
+		return this.SetVal(key_path, val_str, size);
 	}
 	
 	/**
@@ -406,14 +480,7 @@ methodmap ConfigMap < StringMap {
 		if( this==null ) {
 			return false;
 		}
-		PackVal val;
-		bool result = this.GetVal(key_path, val);
-		if( result && val.tag==KeyValType_Value ) {
-			val.data.Reset();
-			val.data.WriteString(str);
-			return true;
-		}
-		return false;
+		return this.SetVal(key_path, str, strlen(str) + 1);
 	}
 	
 	/**
@@ -452,6 +519,21 @@ methodmap ConfigMap < StringMap {
 			delete map;
 		}
 		return map;
+	}
+	
+	/**
+	 * 
+	 * name:      DeleteSection
+	 * @param     key_path : section path name to erase.
+	 * @return    true on if section was successfully deleted, false otherwise.
+	 * @note      to directly access subsections, use a '.' like "root.section1.section2"
+	 *            for keys that have a dot in their name, use '\\.'
+	 */
+	public bool DeleteSection(const char[] key_path) {
+		if( this==null ) {
+			return false;
+		}
+		return this.SetVal(key_path, .val_size = -1);
 	}
 };
 

--- a/addons/sourcemod/scripting/include/cfgmap.inc
+++ b/addons/sourcemod/scripting/include/cfgmap.inc
@@ -287,7 +287,7 @@ methodmap ConfigMap < StringMap {
 	 *
 	 * name:      GetFloat
 	 * @param     key_path : key path to the data you need.
-	 * @param     val : integer reference to store int data.
+	 * @param     val : float reference to store int data.
 	 * @return    Number of chars used, 0 if error.
 	 * @note      to directly access subsections, use a '.' like "root.section1.section2"
 	 *            for keys that have a dot in their name, use '\\.'
@@ -341,6 +341,118 @@ methodmap ConfigMap < StringMap {
 			return val.size - 1;
 		}
 		return 0;
+	}
+	
+	/**
+	 * 
+	 * name:      SetInt
+	 * @param     key_path : key path to the data you need.
+	 * @param     val : integer value to set data to.
+	 * @return    true on success, false if the key doesn't exists.
+	 * @note      to directly access subsections, use a '.' like "root.section1.section2"
+	 *            for keys that have a dot in their name, use '\\.'
+	 */
+	public bool SetInt(const char[] key_path, int i) {
+		if( this==null ) {
+			return false;
+		}
+		PackVal val;
+		bool result = this.GetVal(key_path, val);
+		if( result && val.tag==KeyValType_Value ) {
+			val.data.Reset();
+			char val_str[15];
+			IntToString(i, val_str, sizeof(val_str));
+			val.data.WriteString(val_str);
+			return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * 
+	 * name:      SetFloat
+	 * @param     key_path : key path to the data you need.
+	 * @param     val : float value to set data to.
+	 * @return    true on success, false if the key doesn't exists.
+	 * @note      to directly access subsections, use a '.' like "root.section1.section2"
+	 *            for keys that have a dot in their name, use '\\.'
+	 */
+	public bool SetFloat(const char[] key_path, float f) {
+		if( this==null ) {
+			return false;
+		}
+		PackVal val;
+		bool result = this.GetVal(key_path, val);
+		if( result && val.tag==KeyValType_Value ) {
+			val.data.Reset();
+			char val_str[15];
+			FloatToString(f, val_str, sizeof(val_str));
+			val.data.WriteString(val_str);
+			return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * 
+	 * name:      SetString
+	 * @param     key_path : key path to the data you need.
+	 * @param     str : new string to set.
+	 * @return    true on success, false if the key doesn't exists.
+	 * @note      to directly access subsections, use a '.' like "root.section.key"
+	 *            for keys that have a dot in their name, use '\\.'
+	 */
+	public bool SetString(const char[] key_path, const char[] str) {
+		if( this==null ) {
+			return false;
+		}
+		PackVal val;
+		bool result = this.GetVal(key_path, val);
+		if( result && val.tag==KeyValType_Value ) {
+			val.data.Reset();
+			val.data.WriteString(str);
+			return true;
+		}
+		return false;
+	}
+	
+	/**
+	 * 
+	 * name:      ExportToFile
+	 * @param     sec_name : new section name.
+	 * @param     path : path to store ConfigMap infos.
+	 * @return    true on sucess, false otherwise.
+	 */
+	public bool ExportToFile(const char[] sec_name, const char[] path) {
+		if( this==null ) {
+			return false;
+		}
+		File file = OpenFile(path, "wt");
+		if( file==null ) {
+			return false;
+		}
+		bool res = ConfigMapToFile(this, sec_name, file);
+		delete file;
+		
+		return res;
+	}
+	
+	/**
+	 * 
+	 * name:      Clone
+	 * @param     new_owner : new plugin owner.
+	 * @return    true on sucess, false otherwise.
+	 */
+	public ConfigMap Clone(Handle new_owner) {
+		if( this==null || !new_owner ) {
+			return null;
+		}
+		ConfigMap map = view_as<ConfigMap>(new StringMap());
+		if( !CloneConfigMap(this, map, new_owner) ) {
+			delete map;
+		}
+		
+		return map;
 	}
 };
 
@@ -524,4 +636,93 @@ stock void PrintCfg(ConfigMap cfg) {
 		}
 	}
 	delete snap;
+}
+
+static stock void ReplaceEscapeSeq(char[] str, int size)
+{
+	char list[][][] = {
+		{ "\t", "\\t" },
+		{ "\n", "\\n" },
+		{ "\r", "\\r" }
+	};
+	for( int i; i<sizeof(list); i++) {
+		ReplaceString(str, size, list[i][0], list[i][1]);
+	}
+}
+
+static stock bool ConfigMapToFile(const ConfigMap cfg, const char[] sec_name, const File file, int deep = 0)
+{
+	StringMapSnapshot snap = cfg.Snapshot();
+	if( snap==null ) {
+		delete file;
+		return false;
+	}
+	
+	char[] tab = new char[deep];
+	for( int i; i<deep; i++) tab[i]='\t';
+	file.WriteLine("%s\"%s\" {", tab, sec_name);
+	
+	int size = snap.Length;
+	for( int i; i<size; i++ ) {
+		int strsize = snap.KeyBufferSize(i) + 1;
+		char[] key = new char[strsize];
+		snap.GetKey(i, key, strsize);
+		PackVal pack;
+		cfg.GetArray(key, pack, sizeof(pack));
+		pack.data.Reset();
+		switch( pack.tag ) {
+			case KeyValType_Value: {
+				int key_size = pack.size+10;
+				char[] key_val = new char[key_size];
+				pack.data.ReadString(key_val, key_size);
+				ReplaceEscapeSeq(key_val, key_size);
+				file.WriteLine("%s\t\"%s\"\t \"%s\"", tab, key, key_val);
+			}
+			case KeyValType_Section: {
+				ConfigMap subsection = pack.data.ReadCell();
+				if( !ConfigMapToFile(subsection, key, file, deep + 1) ) {
+					delete snap;
+					file.WriteLine("}");
+					return false;
+				}
+			}
+		}
+	}
+	
+	delete snap;
+	file.WriteLine("%s}", tab);
+	return true;
+}
+
+static stock bool CloneConfigMap(const ConfigMap cfg, ConfigMap new_cfg, Handle new_owner)
+{
+	StringMapSnapshot snap = cfg.Snapshot();
+	if( !snap )
+		return false;
+	
+	int size = snap.Length;
+	for( int i; i<size; i++ ) {
+		int strsize = snap.KeyBufferSize(i) + 1;
+		char[] key_buffer = new char[strsize];
+		snap.GetKey(i, key_buffer, strsize);
+		PackVal pack;
+		cfg.GetArray(key_buffer, pack, sizeof(pack));
+		switch( pack.tag ) {
+			case KeyValType_Value: {
+				Handle data = pack.data;
+				pack.data = view_as<DataPack>(CloneHandle(data, new_owner));
+				new_cfg.SetArray(key_buffer, pack, sizeof(pack));
+			}
+			case KeyValType_Section: {
+				pack.data.Reset();
+				ConfigMap subsec = pack.data.ReadCell();
+				if( !CloneConfigMap(subsec, new_cfg, new_owner) ) {
+					delete snap;
+					return false;
+				}
+			}
+		}
+	}
+	delete snap;
+	return true;
 }

--- a/addons/sourcemod/scripting/include/cfgmap.inc
+++ b/addons/sourcemod/scripting/include/cfgmap.inc
@@ -181,7 +181,7 @@ methodmap ConfigMap < StringMap {
 		if( this==null ) {
 			return false;
 		}
-		///	if "do_erase" is set true, "SetVal" will behave as "RemoveVal", iterate and recursively delete the elements.
+		/// if "do_erase" is set true, "SetVal" will behave as "RemoveVal", iterate and recursively delete the elements.
 		bool do_erase = val_size<0;
 		/// first check if we're getting a singular value OR we iterate through a sectional path.
 		int dot = FindCharInString(key, '.');

--- a/addons/sourcemod/scripting/include/cfgmap.inc
+++ b/addons/sourcemod/scripting/include/cfgmap.inc
@@ -451,7 +451,6 @@ methodmap ConfigMap < StringMap {
 		if( !CloneConfigMap(this, map, new_owner) ) {
 			delete map;
 		}
-		
 		return map;
 	}
 };
@@ -654,7 +653,6 @@ static stock bool ConfigMapToFile(const ConfigMap cfg, const char[] sec_name, co
 {
 	StringMapSnapshot snap = cfg.Snapshot();
 	if( snap==null ) {
-		delete file;
 		return false;
 	}
 	
@@ -682,7 +680,7 @@ static stock bool ConfigMapToFile(const ConfigMap cfg, const char[] sec_name, co
 				ConfigMap subsection = pack.data.ReadCell();
 				if( !ConfigMapToFile(subsection, key, file, deep + 1) ) {
 					delete snap;
-					file.WriteLine("}");
+					file.WriteLine("%s}", tab);
 					return false;
 				}
 			}
@@ -697,9 +695,9 @@ static stock bool ConfigMapToFile(const ConfigMap cfg, const char[] sec_name, co
 static stock bool CloneConfigMap(const ConfigMap cfg, ConfigMap new_cfg, Handle new_owner)
 {
 	StringMapSnapshot snap = cfg.Snapshot();
-	if( !snap )
+	if( !snap ) {
 		return false;
-	
+	}
 	int size = snap.Length;
 	for( int i; i<size; i++ ) {
 		int strsize = snap.KeyBufferSize(i) + 1;

--- a/addons/sourcemod/scripting/include/cfgmap.inc
+++ b/addons/sourcemod/scripting/include/cfgmap.inc
@@ -94,7 +94,7 @@ methodmap ConfigMap < StringMap {
 		
 		SMCError err = g_kvstate.parser.ParseFile(path);
 		//PrintCfg(view_as< ConfigMap >(g_kvstate.top));
-		if( err != SMCError_Okay ) {
+		if( err!=SMCError_Okay ) {
 			char buffer[64];
 			if( g_kvstate.parser.GetErrorString(err, buffer, sizeof(buffer)) ) {
 				LogError("ConfigMap Err (%s) :: **** %s ****", path, buffer);
@@ -102,7 +102,7 @@ methodmap ConfigMap < StringMap {
 				LogError("ConfigMap Err (%s) :: **** Unknown Fatal Parse Error ****", path);
 			}
 			
-			if( g_kvstate.top != null ) {
+			if( g_kvstate.top!=null ) {
 				DeleteCfg(view_as< ConfigMap >(g_kvstate.top));
 			}
 		}
@@ -112,7 +112,7 @@ methodmap ConfigMap < StringMap {
 		delete g_kvstate.enum_stack;
 		
 		StringMap cfg = g_kvstate.top;
-		if( g_kvstate.top != null ) {
+		if( g_kvstate.top!=null ) {
 			g_kvstate.top = null;
 		}
 		return view_as< ConfigMap >(cfg);
@@ -126,7 +126,7 @@ methodmap ConfigMap < StringMap {
 		/// first check if we're getting a singular value OR we iterate through a sectional path.
 		int dot = FindCharInString(key, '.');
 		/// Patch: dot and escaped dot glitching out the hashmap hashing...
-		if( dot==-1 || (dot > 0 && key[dot-1]=='\\') ) {
+		if( dot==-1 || (dot>0 && key[dot-1]=='\\') ) {
 			PackVal val;
 			bool result = this.GetArray(key, val, sizeof(val));
 			if( result && val.tag!=KeyValType_Null ) {
@@ -143,12 +143,12 @@ methodmap ConfigMap < StringMap {
 		ParseTargetPath(key, target_section, sizeof(target_section));
 		
 		ConfigMap itermap = this;
-		while( itermap != null ) {
+		while( itermap!=null ) {
 			int n;
 			char curr_section[PLATFORM_MAX_PATH];
 			/// Patch: allow keys to use dot without interfering with dot path.
-			while( key[i] != 0 ) {
-				if( key[i]=='\\' && key[i+1] != 0 && key[i+1]=='.' ) {
+			while( key[i]!=0 ) {
+				if( key[i]=='\\' && key[i+1]!=0 && key[i+1]=='.' ) {
 					i++;
 					if( n<PLATFORM_MAX_PATH ) {
 						curr_section[n++] = key[i++];
@@ -186,7 +186,7 @@ methodmap ConfigMap < StringMap {
 		/// first check if we're getting a singular value OR we iterate through a sectional path.
 		int dot = FindCharInString(key, '.');
 		/// Patch: dot and escaped dot glitching out the hashmap hashing...
-		if( dot == -1 || (dot > 0 && key[dot-1] == '\\') ) {
+		if( dot==-1 || (dot>0 && key[dot-1]=='\\') ) {
 			PackVal val;
 			bool result = this.GetArray(key, val, sizeof(val));
 			KeyValType tag = val.tag;
@@ -218,12 +218,12 @@ methodmap ConfigMap < StringMap {
 		ParseTargetPath(key, target_section, sizeof(target_section));
 		
 		ConfigMap itermap = this;
-		while( itermap != null ) {
+		while( itermap!=null ) {
 			int n;
 			char curr_section[PLATFORM_MAX_PATH];
 			/// Patch: allow keys to use dot without interfering with dot path.
-			while( key[i] != 0 ) {
-				if( key[i]=='\\' && key[i+1] != 0 && key[i+1]=='.' ) {
+			while( key[i]!=0 ) {
+				if( key[i]=='\\' && key[i+1]!=0 && key[i+1]=='.' ) {
 					i++;
 					if( n<PLATFORM_MAX_PATH ) {
 						curr_section[n++] = key[i++];
@@ -511,7 +511,7 @@ methodmap ConfigMap < StringMap {
 	 * @return    true on sucess, false otherwise.
 	 */
 	public ConfigMap Clone(Handle new_owner) {
-		if( this==null || !new_owner ) {
+		if( this==null || new_owner==null ) {
 			return null;
 		}
 		ConfigMap map = view_as<ConfigMap>(new StringMap());


### PR DESCRIPTION
-Useful Setters function to dynamically change something
-ExportToFile: save everything in the ConfigMap to a new file, tho it may look messy, since keys are not very well arranged
-Clone: allows you to clone the entire ConfigMap for you to use outside of main plugin
I might add `ConfigMap.DeleteSection`/`ConfigMap.CreateSection` if that sounds useful