### PR TITLE
Update VSH2_GetConfigMap

### DIFF
--- a/addons/sourcemod/scripting/include/cfgmap.inc
+++ b/addons/sourcemod/scripting/include/cfgmap.inc
@@ -517,7 +517,7 @@ methodmap ConfigMap < StringMap {
 		
 		ConfigMap map = view_as< ConfigMap >(new StringMap());
 		if( !CloneConfigMap(this, map, new_owner_pl) ) {
-			delete map;
+			DeleteCfg(map);
 		}
 		return map;
 	}

--- a/addons/sourcemod/scripting/include/vsh2.inc
+++ b/addons/sourcemod/scripting/include/vsh2.inc
@@ -646,7 +646,7 @@ native void VSH2_StopMusic(bool reset_time=true);
  * returns the internal ConfigMap instance read from 'vsh2.cfg'.
  * @noparam
  * @return          internal config map used by VSH2.
- * @note            DO NOT RUN DELETE FUNCTION ON THE INTERNAL CONFIGMAP.
+ * @note            the handle MUST be freed with DeleteCfg
  */
 native ConfigMap VSH2_GetConfigMap();
 

--- a/addons/sourcemod/scripting/vsh2.sp
+++ b/addons/sourcemod/scripting/vsh2.sp
@@ -1474,7 +1474,7 @@ public int Native_StopMusic(Handle plugin, int numParams)
 
 public any Native_GetMainConfig(Handle plugin, int numParams)
 {
-	return g_vsh2.m_hCfg;
+	return g_vsh2.m_hCfg.Clone(plugin);
 }
 
 public int Native_VSH2_ConvertToMinion(Handle plugin, int numParams)


### PR DESCRIPTION
the `ConfigMap` must be cloned in order to access its `DataPack`s