### PR TITLE
revert to default rage type for FF2

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -7,7 +7,7 @@
 #include <sdkhooks>
 
 #define PLYR           35
-#define PLUGIN_VERSION "1.0.1b"
+#define PLUGIN_VERSION "1.0.3b"
 
 #include <cfgmap>
 #include "modules/stocks.inc"

--- a/addons/sourcemod/scripting/modules/ff2/handles.sp
+++ b/addons/sourcemod/scripting/modules/ff2/handles.sp
@@ -70,7 +70,7 @@ void Call_FF2OnAbility(const FF2Player player, FF2CallType_t call_type)
 		FormatEx(pl_ab[0], sizeof(pl_ab[]), "%s.slot", cfg_key);
 		if( !cfg.GetInt(pl_ab[0], view_as< int >(cur_type)) ) {
 			FormatEx(pl_ab[0], sizeof(pl_ab[]), "%s.arg0", cfg_key);
-			if( !cfg.GetInt(pl_ab[0], view_as< int >(cur_type)) )
+			if( !cfg.GetInt(pl_ab[0], view_as< int >(cur_type)) || !cur_type )
 				cur_type = CT_RAGE;
 		}
 		

--- a/addons/sourcemod/scripting/modules/ff2/sound_list.sp
+++ b/addons/sourcemod/scripting/modules/ff2/sound_list.sp
@@ -4,6 +4,7 @@
  * path = full song path name
  * name = > "slot*_*": <key position>_<value>
  * 		  > "song name"
+ *		  > String To Replace or unused for "catch_phrase"
  * artist = empty or contains artist's name
  * time = 0.0, or song duration
  */
@@ -14,11 +15,21 @@ enum struct FF2SoundIdentity  {
 	char artist[32];
 	float time;
 	
-	void Init(const char[] path, float time, const char[] name = "Unknown Song", const char[] artist = "Unknown artist") {
+	void Init(const char[] path, float time, const char[] name = "", const char[] artist = "Unknown artist") {
 		strcopy(this.path, sizeof(FF2SoundIdentity::path), path);
 		strcopy(this.name, sizeof(FF2SoundIdentity::name), name);
 		strcopy(this.artist, sizeof(FF2SoundIdentity::artist), artist);
 		this.time = time;
+	}
+	
+	void PrintToAll() {
+		if( !this.name[0] )
+			return;
+		for( int i=1;i<MaxClients;i++ ) {
+			if( IsClientInGame(i) ) {
+				FPrintToChat(i, "Now Playing {blue}%s{default} - {orange}%s{default}", this.name, this.artist);
+			}
+		}
 	}
 }
 
@@ -44,7 +55,7 @@ methodmap FF2SoundList < ArrayList {
 	
 	public bool RandomSound(FF2SoundIdentity snd_id) {
 		if( !this.Empty ) {
-			int rand = GetRandomInt(0, this.Length - 1);
+			int rand = GetURandomInt() % this.Length;
 			return( this.At(rand, snd_id) );
 		}
 		return false;

--- a/addons/sourcemod/scripting/modules/ff2/subplugins.sp
+++ b/addons/sourcemod/scripting/modules/ff2/subplugins.sp
@@ -112,8 +112,7 @@ static Handle _FindPlugin(const char[] name)
 	char pl_name[PLATFORM_MAX_PATH];
 	FormatEx(pl_name, sizeof(pl_name), "freaks\\%s.ff2", name);
 	Handle pl = FindPluginByFile(pl_name);
-	if( !pl || GetPluginStatus(pl)!=Plugin_Running )
-	{
+	if( !pl || GetPluginStatus(pl)!=Plugin_Running ) {
 		LogError("[VSH2/FF2] Failed to load plugin: %s", pl_name);
 		return null;
 	}

--- a/addons/sourcemod/scripting/modules/ff2/vsh2_bridge.sp
+++ b/addons/sourcemod/scripting/modules/ff2/vsh2_bridge.sp
@@ -60,7 +60,7 @@ void RemoveVSH2Bridge()
 	VSH2_Unhook(OnLastPlayer, OnLastPlayerFF2);
 	VSH2_Unhook(OnSoundHook, OnSoundHookFF2);
 	VSH2_Unhook(OnScoreTally, OnScoreTallyFF2);
-	
+
 	ff2_cfgmgr.DeleteAll();
 	delete ff2_cfgmgr;
 }
@@ -90,19 +90,19 @@ public Action OnCallDownloadsFF2()
 	PrecacheScriptList(script_sounds, sizeof(script_sounds));
 	PrecacheSoundList(basic_sounds, sizeof(basic_sounds));
 	PrepareSound("saxton_hale/9000.wav");
-	
+
 	ProcessOnCallDownload();
-	
+
 	return Plugin_Continue;
 }
 
 public void OnBossMenuFF2(Menu& menu, const VSH2Player player)
 {
 	char id_menu[10];
-	
+
 	StringMapSnapshot snap = ff2_cfgmgr.Snapshot();
 	char char_name[48];
-	
+
 	ConfigMap cfg;
 	int tmp;
 	for( int i = snap.Length - 1; i >= 0; i-- ) {
@@ -112,7 +112,7 @@ public void OnBossMenuFF2(Menu& menu, const VSH2Player player)
 			cfg = curIdentity.hCfg.GetSection("character");
 			if( !cfg.Get("name", char_name, sizeof(char_name)) || (cfg.GetInt("blocked", tmp) && tmp) )
 				continue;
-			
+
 			IntToString(curIdentity.VSH2ID, id_menu, sizeof(id_menu));
 			menu.AddItem(id_menu, char_name);
 		}
@@ -125,13 +125,13 @@ public void OnBossCalcHealthFF2(const VSH2Player player, int& max_health, const 
 	FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(player).iBossType, identity) )
 		return;
-	
+
 	ConfigMap cfg = ToFF2Player(player).iCfg;
 	char formula[64];
 	if( cfg.Get("health_formula", formula, sizeof(formula)) ) {
 		max_health = RoundToFloor(ParseFormula(formula, boss_count + red_players));
 	}
-	
+
 	int lives;
 	if( cfg.GetInt("lives", lives) && lives > 1 ) {
 		ToFF2Player(player).iLives = lives;
@@ -143,23 +143,23 @@ public Action OnBossSelectedFF2(const VSH2Player player)
 {
 	if( IsVoteInProgress() )
 		return Plugin_Continue;
-	
+
 	FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(player).iBossType, identity) )
 		return Plugin_Continue;
-		
+	
 	/// Handle callback
 	{
 		char name[MAX_BOSS_NAME_SIZE]; name = identity.szName;
 		Action res = Call_OnBossSelected(ToFF2Player(player), name, false);
-		
+
 		if( res >= Plugin_Changed ) {
 			if( ff2_cfgmgr.FindIdentityByName(name, identity) ) {
 				player.SetPropInt("iBossType", identity.VSH2ID);
 			}
 		}		
 	}
-	
+
 	ff2.m_plugins.LoadPlugins(identity.ablist);
 	char help[128] = "";
 	{
@@ -169,64 +169,64 @@ public Action OnBossSelectedFF2(const VSH2Player player)
 		if( !identity.hCfg.Get(language, help, sizeof(help)) )
 			return Plugin_Changed;
 	}
-	
+
 	Panel panel = new Panel();
-	
+
 	panel.SetTitle(help);
 	panel.DrawItem("Exit");
 	panel.Send(player.index, DummyHintPanel, 10);
-	
+
 	delete panel;
-	
+
 	return Plugin_Changed;
 }
 
 public void OnBossThinkFF2(const VSH2Player vsh2player)
 {
 	FF2Player player = ToFF2Player(vsh2player);
-	
+
 	static FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(player).iBossType, identity) )
 		return;
-	
+
 	///	Handle speed think
 	{
 		float flstart;
 		if( !player.iCfg.GetFloat("speed", flstart) && !player.iCfg.GetFloat("maxspeed", flstart) )
 			flstart = 350.0;
-		
+
 		float flmin;
 		if( !player.iCfg.GetFloat("minspeed", flmin) )
 			flmin = 100.0;
-		
+
 		player.SpeedThink(flstart, flmin);
 		player.GlowThink(0.1);
 	}
-	
+
 	float flCharge = player.GetPropFloat("flCharge");
 	float flRage = player.GetPropFloat("flRAGE");
 	int client = player.index;
 	ConfigMap cfg = player.iCfg;
 	static char buffer[PLATFORM_MAX_PATH];
-	
+
 	///	Handle super jump
 	{
 		float flmin;
 		if( !cfg.GetFloat("min super jump", flmin) )
 			flmin = 25.0;
-		
+
 		if( player.SuperJumpThink(2.5, flmin) ) {
 			if ( !cfg.GetFloat("super jump reset", flmin) )
 				flmin = -100.0;
 			player.SuperJump(flCharge, flmin);
-			
+
 			FF2SoundList snd_list = identity.sndHash.GetList("sound_ability");
 			if( RandomAbilitySound(snd_list, CT_CHARGE, buffer, sizeof(buffer)) ) {
 				player.PlayVoiceClip(buffer, VSH2_VOICE_ABILITY);
 			}
 		}
 	}
-	
+
 	///	Handle weighdown
 	{
 		if( !player.bNoWeighdown ) {
@@ -237,13 +237,13 @@ public void OnBossThinkFF2(const VSH2Player vsh2player)
 				if( flags & FL_ONGROUND )
 					player.SetPropFloat("flWeighDown", 0.0);
 				else player.SetPropFloat("flWeighDown", GetGameTime() + 0.07);
-				
+
 				if( (buttons & IN_DUCK) && player.GetPropFloat("flWeighDown") >= 0.1 ) {
 					float ang[3]; GetClientEyeAngles(client, ang);
 					if( ang[0] > 60.0 ) {
 						if( !cfg.GetFloat("weighdown cooldown", ang[0]) )
 							ang[0] = 5.0;
-						
+
 						player.SetPropFloat("flWeighdownCd", GetGameTime() + ang[0]);
 						player.WeighDown(0.0);
 					}
@@ -254,32 +254,36 @@ public void OnBossThinkFF2(const VSH2Player vsh2player)
 			}
 		}
 	}
-	
+
 	buffer[0] = '\0';
-	
+
 	if( !player.bHideHUD )
 		Format(buffer, sizeof(buffer), "Super-Jump: %i%%\n", player.GetPropInt("bSuperCharge") ? 1000 : RoundFloat(flCharge) * 4);
-	
+
 	SetHudTextParams(-1.0, 0.77, 0.15, 255, 255, 255, 255);
-	
+
 	if( flRage >= 100.0 ) {
 		Format(buffer, sizeof(buffer), "%sCall for medic to activate your \"RAGE\" ability", buffer);
 	} else {
 		Format(buffer, sizeof(buffer), "%sRage is %.1f percent ready", buffer, flRage);
 	}
-	
+
 	ShowSyncHudText(client, ff2.m_hud[HUD_Jump], "%s", buffer);
 }
 
 public Action OnBossSuperJumpFF2(const VSH2Player vsh2player)
 {
 	FF2Player player = ToFF2Player(vsh2player);
+	FF2Identity identity;
+	if( !ff2_cfgmgr.FindIdentity(player.iBossType, identity) )
+		return Plugin_Continue;
+
 	Call_FF2OnAbility(player, CT_CHARGE);
-	
+
 	if( player.bNoSuperJump ) {
 		return Plugin_Stop;
 	}
-	
+
 	return Plugin_Continue;
 }
 
@@ -293,7 +297,7 @@ public void OnBossModelTimerFF2(const VSH2Player player)
 	FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(player).iBossType, identity) )
 		return;
-	
+
 	int client = player.index;
 	char model[PLATFORM_MAX_PATH];
 	if( ToFF2Player(player).iCfg.Get("model", model, sizeof(model)) ) {
@@ -308,22 +312,22 @@ public void OnBossEquippedFF2(const VSH2Player player)
 	FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(player).iBossType, identity) )
 		return;
-	
+
 	ConfigMap cfg = ToFF2Player(player).iCfg;
 	char name[MAX_BOSS_NAME_SIZE]; cfg.Get("name", name, sizeof(name));
-	
+
 	player.SetName(name);
 	player.RemoveAllItems();
-	
+
 	ConfigMap wepcfg;
-	
+
 	char attr[64]; int index; int lvl; int qual;
 	for( int i = 1; i < 4; i++ ) {
 		FormatEx(name, sizeof(name), "weapon%i", i);
 		wepcfg = cfg.GetSection(name);
 		if( !wepcfg )
 			break;
-		
+
 		if( !wepcfg.GetInt("index", index) )
 			continue;
 		if( !wepcfg.Get("name", name, sizeof(name)) )
@@ -332,7 +336,7 @@ public void OnBossEquippedFF2(const VSH2Player player)
 			lvl = 39;
 		if( !wepcfg.GetInt("quality", qual) )
 			qual = 5;
-		
+
 		wepcfg.Get("attributes", attr, sizeof(attr));
 		int new_weapon = player.SpawnWeapon(name, index, lvl, qual, attr);
 		SetEntPropEnt(player.index, Prop_Send, "m_hActiveWeapon", new_weapon);
@@ -345,12 +349,12 @@ public void OnBossInitializedFF2(const VSH2Player vsh2player)
 	FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(player.iBossType, identity) )
 		return;
-	
+
 	ConfigMap cfg = player.iCfg;
 	int cls;
 	if( !cfg.GetInt("class", cls) )
 		cls = GetRandomInt(1, 8);
-	
+
 	SetEntProp(player.index, Prop_Send, "m_iClass", cls);
 	{
 		int tmp;
@@ -359,18 +363,18 @@ public void OnBossInitializedFF2(const VSH2Player vsh2player)
 		player.bHideHUD 	= cfg.GetInt("No HUD", tmp) && tmp;
 	}
 	
-	
+
 	/// Process Set Companion
 	{
 		char companion[48];
 		if( !cfg.Get("companion", companion, sizeof(companion)) || !companion[0] ) {
 			return;
 		}
-		
+
 		if( !ff2_cfgmgr.FindIdentityByName(companion, identity) ) {
 			return;
 		}
-		
+
 		FF2Player[] next_players = new FF2Player[MaxClients];
 		int count = VSH2GameMode.GetQueue(view_as< VSH2Player >(next_players));
 		int limit = ff2.m_cvars.m_companion_min.IntValue;
@@ -388,7 +392,7 @@ public void OnBossKillBuildingFF2(const VSH2Player player, const int building, E
 	FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(player).iBossType, identity) )
 		return;
-	
+
 	FF2SoundList list = identity.sndHash.GetList("sound_kill_buildable");
 	FF2SoundIdentity snd_id;
 	if( list && list.RandomSound(snd_id) )
@@ -400,13 +404,13 @@ public Action OnBossPlayIntroFF2(const VSH2Player player)
 	FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(player).iBossType, identity) )
 		return Plugin_Continue;
-	
+
 	FF2SoundList list = identity.sndHash.GetList("sound_begin");
 	FF2SoundIdentity snd_id;
 	
 	if( list && list.RandomSound(snd_id) )
 		player.PlayVoiceClip(snd_id.path, VSH2_VOICE_INTRO);
-		
+
 	return Plugin_Handled;
 }
 
@@ -414,13 +418,13 @@ public void OnPlayerKilledFF2(const VSH2Player attacker, const VSH2Player victim
 {
 	if( event.GetInt("death_flags") & TF_DEATHFLAG_DEADRINGER )
 		return;
-	
+
 	FF2Identity identity[2]; bool bState[2];
 	bState[0] = ff2_cfgmgr.FindIdentity(ToFF2Player(attacker).iBossType, identity[0]);
 	bState[1] = ff2_cfgmgr.FindIdentity(ToFF2Player(victim).iBossType, identity[1]);
 	if( !bState[0] && !bState[1] )
 		return;
-	
+
 	///	Victim is the boss
 	if( bState[1] ) {
 		FF2Player player = ToFF2Player(victim);
@@ -431,7 +435,7 @@ public void OnPlayerKilledFF2(const VSH2Player attacker, const VSH2Player victim
 		if( curtime <= attacker.GetPropFloat("flKillSpree") )
 			attacker.SetPropInt("iKills", attacker.GetPropInt("iKills") + 1);
 		else attacker.SetPropInt("iKills", 0);
-		
+
 		if( attacker.GetPropInt("iKills") == 3 && vsh2_gm.iLivingReds != 1 ) {
 			static FF2SoundIdentity snd_id;
 			FF2SoundList list = identity[1].sndHash.GetList("sound_kspree");
@@ -442,11 +446,11 @@ public void OnPlayerKilledFF2(const VSH2Player attacker, const VSH2Player victim
 			/// play sounn_hit*
 			{
 				static const char tf_classes[] =  { "scout", "sniper", "soldier", "demoman", "medic", "heavy", "pyro", "spy", "engineer" };
-				
+
 				int cls = view_as< int >(TF2_GetPlayerClass(victim.index)) - 1;
 				static char _key[36];
 				FormatEx(_key, sizeof(_key), "sound_hit_%s", tf_classes[cls]);
-				
+
 				static FF2SoundIdentity snd_id;
 				FF2SoundList list = identity[1].sndHash.GetList(_key);
 				if( list && list.RandomSound(snd_id) ) {
@@ -469,15 +473,15 @@ public void OnPlayerHurtFF2(const VSH2Player attacker, const VSH2Player victim, 
 	FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(victim).iBossType, identity) )
 		return;
-	
+
 	int damage = event.GetInt("damageamount");
 	victim.GiveRage(damage);
-	
+
 	FF2Player player = ToFF2Player(victim);
 	int curHealth = player.iHealth;
 	if( player.iLives <= 1 || damage < curHealth )
 		return;
-	
+
 	Action res = Call_OnBossLoseLife(player);
 	if( res <= Plugin_Changed ) {
 		if( player.iLives > 1 ) {
@@ -493,7 +497,7 @@ public void OnPlayerAirblastedFF2(const VSH2Player airblaster, const VSH2Player 
 	FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(airblasted).iBossType, identity) )
 		return;
-	
+
 	float rage = airblasted.GetPropFloat("flRAGE");
 	airblasted.SetPropFloat("flRAGE", rage + ff2.m_cvars.m_flairblast.FloatValue);
 }
@@ -504,7 +508,7 @@ public Action OnBossMedicCallFF2(const VSH2Player player)
 	FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(player).iBossType, identity) )
 		return;
-	
+
 	Call_FF2OnAbility(ToFF2Player(player), CT_RAGE);
 	if( !player.GetPropAny("bSupressRAGE") )
 		player.SetPropFloat("flRAGE", 0.0);
@@ -515,17 +519,17 @@ public Action OnBossJaratedFF2(const VSH2Player victim, const VSH2Player attacke
 	FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(victim).iBossType, identity) )
 		return Plugin_Continue;
-	
+
 	FF2Player player = ToFF2Player(victim);
 	float rage = player.flRAGE;
 	Action res = Call_OnBossJarated(ToFF2Player(victim), ToFF2Player(attacker), rage);
 	if( res==Plugin_Stop )
 		return Plugin_Changed;
-	
+
 	rage -= ff2.m_cvars.m_fljarate.FloatValue;
 	if( rage <= 0.0 )
 		rage = 0.0;
-	
+
 	player.flRAGE = rage;
 	return Plugin_Changed;
 }
@@ -535,7 +539,7 @@ public void OnRoundEndInfoFF2(const VSH2Player player, bool bossBool, char messa
 	FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(player).iBossType, identity) )
 		return;
-	
+
 	FF2SoundIdentity snd_id;
 	if( bossBool ) {
 		FF2SoundList list = identity.sndHash.GetList("sound_win");
@@ -554,12 +558,12 @@ public Action OnMusicFF2(char song[PLATFORM_MAX_PATH], float& time, const VSH2Pl
 	static FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(player).iBossType, identity) )
 		return Plugin_Continue;
-	
+
 	Action res = Call_OnMusic(ToFF2Player(player), song, time);
 	if( res > Plugin_Changed ) {
 		return res;
 	}
-	
+
 	/// hmm...
 	{
 		FF2SoundIdentity snd_id;
@@ -583,7 +587,7 @@ public void OnBossDeathFF2(const VSH2Player player)
 	FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(player).iBossType, identity) )
 		return;
-	
+
 	FF2SoundList list = identity.sndHash.GetList("sound_death");
 	FF2SoundIdentity snd_id;
 	if( list && list.RandomSound(snd_id) )
@@ -597,7 +601,7 @@ public Action OnMarketGardenedFF2( VSH2Player victim, int& attacker, int& inflic
 	FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(victim).iBossType, identity) )
 		return Plugin_Continue;
-	
+
 	Call_FF2OnAbility(ToFF2Player(victim), CT_BOSS_MG);
 	return Plugin_Continue;
 }
@@ -609,19 +613,19 @@ public Action OnStabbedFF2( VSH2Player victim, int& attacker, int& inflictor,
 	FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(victim).iBossType, identity) )
 		return Plugin_Continue;
-	
+
 	Action res = Call_OnBossStabbed(ToFF2Player(victim), FF2Player(attacker));
 	if( res==Plugin_Stop )
 		return Plugin_Changed;
 	else if( res==Plugin_Handled )
 		damage = 0.0;
-		
+
 	FF2SoundIdentity snd_id;
 	FF2SoundList list = identity.sndHash.GetList("sound_stabbed");
 	if( list && list.RandomSound(snd_id) ) {
 		victim.PlayVoiceClip(snd_id.path, VSH2_VOICE_LOSE);
 	}
-	
+
 	Call_FF2OnAbility(ToFF2Player(victim), CT_BOSS_STABBED);
 	return Plugin_Continue;
 }
@@ -631,11 +635,11 @@ public Action OnSoundHookFF2(const VSH2Player player, char sample[PLATFORM_MAX_P
 	FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(player).iBossType, identity) )
 		return Plugin_Continue;
-	
+
 	if( channel==SNDCHAN_VOICE || (channel==SNDCHAN_STATIC && !StrContains(sample, "vo")) ) {
 		FF2SoundList list = identity.sndHash.GetList("catch_phrase");
 		static FF2SoundIdentity snd_id;
-		
+
 		if( list && list.RandomSound(snd_id) )
 			strcopy(sample, sizeof(sample), snd_id.path);
 		else {
@@ -644,12 +648,12 @@ public Action OnSoundHookFF2(const VSH2Player player, char sample[PLATFORM_MAX_P
 				int max = list.Length;
 				int[] entries = new int[max];
 				int count;
-				
+
 				for( int i = 0; i < max; i++ ) {
 					if( list.At(i, snd_id) && !StrContains(snd_id.path, sample) )
 						entries[count++] = i;
 				}
-				
+
 				if( count ) {
 					int pos = GetRandomInt(0, count - 1);
 					if( list.At(entries[pos], snd_id) ) {
@@ -658,7 +662,7 @@ public Action OnSoundHookFF2(const VSH2Player player, char sample[PLATFORM_MAX_P
 				}
 			}
 		}
-		
+
 		bool bSoundBlock;
 		if( identity.hCfg.GetInt("character.sound_block_vo", bSoundBlock) && bSoundBlock ) {
 			return Plugin_Stop;
@@ -672,7 +676,7 @@ public void OnLastPlayerFF2(const VSH2Player player)
 	FF2Identity identity;
 	if( !ff2_cfgmgr.FindIdentity(ToFF2Player(player).iBossType, identity) )
 		return;
-	
+
 	FF2SoundList list = identity.sndHash.GetList("sound_lastman");
 	FF2SoundIdentity snd_id;
 	if( list && list.RandomSound(snd_id) ) {
@@ -692,17 +696,17 @@ public void OnScoreTallyFF2(const VSH2Player player, int& points_earned, int& qu
 public void FinishQueueArray()
 {
 	VSH2GameMode.SetProp("bQueueChecking", false);
-	
+
 	int[] points = new int[MaxClients];
 	for( int i=1; i<=MaxClients; i++ )
 		points[i] = ff2.m_queuePoints[i];
-	
+
 	Action res = Call_OnSetScore(points);
 	if( res == Plugin_Changed ) {
 		for( int i=1; i<=MaxClients; i++ ) {
 			if( !IsClientInGame(i) )
 				continue;
-			
+
 			FF2Player player = FF2Player(i);
 			player.SetPropInt("iQueue", points[i] - ff2.m_queuePoints[i] + player.GetPropInt("iQueue"));
 		}
@@ -710,7 +714,7 @@ public void FinishQueueArray()
 		for( int i=1; i<=MaxClients; i++ ) {
 			if( !IsClientInGame(i) )
 				continue;
-			
+
 			FF2Player player = FF2Player(i);
 			player.SetPropInt("iQueue", player.GetPropInt("iQueue") - ff2.m_queuePoints[i]);
 		}

--- a/addons/sourcemod/scripting/modules/ff2/vsh2_bridge.sp
+++ b/addons/sourcemod/scripting/modules/ff2/vsh2_bridge.sp
@@ -207,6 +207,7 @@ public void OnBossThinkFF2(const VSH2Player vsh2player)
 	float flRage = player.GetPropFloat("flRAGE");
 	int client = player.index;
 	ConfigMap cfg = player.iCfg;
+	static char buffer[PLATFORM_MAX_PATH];
 	
 	///	Handle super jump
 	{
@@ -220,9 +221,8 @@ public void OnBossThinkFF2(const VSH2Player vsh2player)
 			player.SuperJump(flCharge, flmin);
 			
 			FF2SoundList snd_list = identity.sndHash.GetList("sound_ability");
-			char snd_path[PLATFORM_MAX_PATH];
-			if( RandomAbilitySound(snd_list, CT_CHARGE, snd_path, sizeof(snd_path)) ) {
-				player.PlayVoiceClip(snd_path, VSH2_VOICE_ABILITY);
+			if( RandomAbilitySound(snd_list, CT_CHARGE, buffer, sizeof(buffer)) ) {
+				player.PlayVoiceClip(buffer, VSH2_VOICE_ABILITY);
 			}
 		}
 	}
@@ -255,15 +255,20 @@ public void OnBossThinkFF2(const VSH2Player vsh2player)
 		}
 	}
 	
-	if( player.bHideHUD )
-		return;
+	buffer[0] = '\0';
+	
+	if( !player.bHideHUD )
+		Format(buffer, sizeof(buffer), "Super-Jump: %i%%\n", player.GetPropInt("bSuperCharge") ? 1000 : RoundFloat(flCharge) * 4);
 	
 	SetHudTextParams(-1.0, 0.77, 0.15, 255, 255, 255, 255);
+	
 	if( flRage >= 100.0 ) {
-		ShowSyncHudText(client, ff2.m_hud[HUD_Jump], "Super-Jump: %i%%\nCall for medic to activate your \"RAGE\" ability", player.GetPropInt("bSuperCharge") ? 1000 : RoundFloat(flCharge) * 4);
+		Format(buffer, sizeof(buffer), "%sCall for medic to activate your \"RAGE\" ability", buffer);
 	} else {
-		ShowSyncHudText(client, ff2.m_hud[HUD_Jump], "Super-Jump: %i%%\nRage is %.1f percent ready", player.GetPropInt("bSuperCharge") ? 1000 : RoundFloat(flCharge) * 4, flRage);
+		Format(buffer, sizeof(buffer), "%sRage is %.1f percent ready", buffer, flRage);
 	}
+	
+	ShowSyncHudText(client, ff2.m_hud[HUD_Jump], "%s", buffer);
 }
 
 public Action OnBossSuperJumpFF2(const VSH2Player vsh2player)


### PR DESCRIPTION
I also noticed that [_BossDeath](https://github.com/VSH2-Devs/Vs-Saxton-Hale-2/blob/develop/addons/sourcemod/scripting/modules/handler.sp#L933) gets called if the boss was using dead ringer, you might wanna check if it's true before calling or pass deathflags as a param instead