### PR TITLE
Changed section handling when cloning configmap

### DIFF
--- a/addons/sourcemod/scripting/include/cfgmap.inc
+++ b/addons/sourcemod/scripting/include/cfgmap.inc
@@ -921,7 +921,7 @@ static stock bool CloneConfigMap(const ConfigMap cfg, ConfigMap new_cfg, Handle 
 				ConfigMap new_subsec = view_as< ConfigMap >(new StringMap());
 
 				DataPack val = new DataPack();
-				val.WriteCell(CloneHandle(new_subsec, new_owner_pl));
+				val.WriteCell(new_subsec);
 				section_pack.data = view_as< DataPack >(CloneHandle(val, new_owner_pl));
 				delete val;
 
@@ -933,10 +933,8 @@ static stock bool CloneConfigMap(const ConfigMap cfg, ConfigMap new_cfg, Handle 
 
 				if( !CloneConfigMap(subsec, new_subsec, new_owner_pl) ) {
 					delete snap;
-					delete new_subsec;
 					return false;
 				}
-				delete new_subsec;
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/include/cfgmap.inc
+++ b/addons/sourcemod/scripting/include/cfgmap.inc
@@ -914,12 +914,29 @@ static stock bool CloneConfigMap(const ConfigMap cfg, ConfigMap new_cfg, Handle 
 				new_cfg.SetArray(key_buffer, pack, sizeof(pack));
 			}
 			case KeyValType_Section: {
+				PackVal section_pack;
+				section_pack.size = pack.size;
+				section_pack.tag = pack.tag;
+
+				ConfigMap new_subsec = view_as< ConfigMap >(new StringMap());
+
+				DataPack val = new DataPack();
+				val.WriteCell(CloneHandle(new_subsec, new_owner_pl));
+				section_pack.data = view_as< DataPack >(CloneHandle(val, new_owner_pl));
+				delete val;
+
+				new_cfg.SetArray(key_buffer, section_pack, sizeof(section_pack));
+
 				pack.data.Reset();
+
 				ConfigMap subsec = pack.data.ReadCell();
-				if( !CloneConfigMap(subsec, new_cfg, new_owner_pl) ) {
+
+				if( !CloneConfigMap(subsec, new_subsec, new_owner_pl) ) {
 					delete snap;
+					delete new_subsec;
 					return false;
 				}
+				delete new_subsec;
 			}
 		}
 	}


### PR DESCRIPTION
This pull request aims to solve #169 : "Config map does not properly clone across plugins"

### source of the issue:
When the key-value pair was being copies over from the original config map it's fields and those of it's subsections would be put in the top domain of the config

The changes in this PR create new configmaps from each subsection to maintain it's original structure and pass ownership to the destined plugin.