### PR TITLE
Sync FF2 with SM version

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -7,7 +7,7 @@
 #include <sdkhooks>
 
 #define PLYR           35
-#define PLUGIN_VERSION "1.0.5b"
+#define PLUGIN_VERSION "1.0.65b"
 
 #include <cfgmap>
 #include "modules/stocks.inc"
@@ -36,7 +36,6 @@ enum {
 };
 
 enum struct FF2ConVars {
-	ConVar m_enabled;
 	ConVar m_version;
 	ConVar m_fljarate;
 	ConVar m_flairblast;
@@ -70,20 +69,23 @@ FF2CompatPlugin ff2;
 VSH2GameMode    vsh2_gm;
 
 #include "modules/ff2/utils.sp"
+#include "modules/ff2/gamemode.sp"
 #include "modules/ff2/forwards.sp"
-#include "modules/ff2/handles.sp"
-#include "modules/ff2/formula_parser.sp"
+
+#include "modules/ff2/handler.sp"
 #include "modules/ff2/vsh2_bridge.sp"
+
 #include "modules/ff2/natives.sp"
 #include "modules/ff2/console.sp"
-#include "modules/ff2/gamemode.sp"
+#include "modules/ff2/formula_parser.sp"
 
 
 public void OnPluginEnd()
 {
 	if( ff2.m_vsh2 ) {
-		FF2GameMode.RemoveSubplugins();
+		FF2PluginList.ForceUnloadAllSubPlugins();
 		FF2GameMode.UnhookFromVSH2();
+		ff2.m_vsh2 = false;
 	}
 }
 
@@ -100,7 +102,7 @@ public void OnLibraryAdded(const char[] name)
 public void OnMapEnd()
 {
 	if( ff2.m_vsh2 ) {
-		FF2GameMode.RemoveSubplugins();
+		FF2GameMode.RemoveSubPlugins();
 		FF2GameMode.RemoveCfgMgr();
 
 		char pack[48];
@@ -114,7 +116,7 @@ public void OnLibraryRemoved(const char[] name)
 	if( StrEqual(name, "VSH2") && ff2.m_vsh2 ) {
 		ff2.m_vsh2 = false;
 		
-		FF2GameMode.RemoveSubplugins(true);
+		FF2GameMode.RemoveSubPlugins(true);
 		
 		FF2GameMode.UnhookFromVSH2();    /// ff2_cfgmgr will be deleted here
 		DeleteCfg(ff2.m_charcfg);

--- a/addons/sourcemod/scripting/freaks/ff2_vsh2defaults.sp
+++ b/addons/sourcemod/scripting/freaks/ff2_vsh2defaults.sp
@@ -64,7 +64,7 @@ enum struct _ConVars {
 		this.ff2_solo_shame 		= FindConVar("ff2_solo_shame");
 	}
 }
-_ConVars m_ConVars;
+_ConVars ConVars;
 
 
 #define EXPLOSIVE_DANCE_ABILITY	"rage_explosive_dance"	
@@ -200,7 +200,7 @@ public void OnMapStart()
 
 void OnPluginStart2()
 {
-	m_ConVars.Init();
+	ConVars.Init();
 	
 	AbilityPool = new AbilityPool_t();
 	
@@ -529,10 +529,10 @@ Action Timer_Rage_Stun(Handle timer, FF2Player cur_boss)
 	int ignore = cur_boss.GetArgI(this_plugin_name, STUN_ABILITY, "uber", 1);
 
  /// Friendly Fire
-	bool friendly = cur_boss.GetArgB(this_plugin_name, STUN_ABILITY, "friendly", m_ConVars.mp_friendlyfire.BoolValue);
+	bool friendly = cur_boss.GetArgB(this_plugin_name, STUN_ABILITY, "friendly", ConVars.mp_friendlyfire.BoolValue);
 
  /// Remove Parachute
-	bool removeBaseJumperOnStun = cur_boss.GetArgB(this_plugin_name, STUN_ABILITY, "basejumper", m_ConVars.ff2_base_jumper_stun.BoolValue);
+	bool removeBaseJumperOnStun = cur_boss.GetArgB(this_plugin_name, STUN_ABILITY, "basejumper", ConVars.ff2_base_jumper_stun.BoolValue);
 
  /// Max Duration
 	float maxduration = cur_boss.GetArgF(this_plugin_name, STUN_ABILITY, "max", 6.0);
@@ -566,7 +566,7 @@ Action Timer_Rage_Stun(Handle timer, FF2Player cur_boss)
 	if( !count )
 		return Plugin_Continue;
 
-	if( count == 1 && (duration != soloduration || m_ConVars.ff2_solo_shame.BoolValue) ) {
+	if( count == 1 && (duration != soloduration || ConVars.ff2_solo_shame.BoolValue) ) {
 		char bossName[MAX_BOSS_NAME_SIZE];
 		if( cur_boss.GetName(bossName) )
 			FPrintToChatAll("{blue}%s{default} used {red}solo rage{default}!", bossName);
@@ -655,7 +655,7 @@ void Rage_Stun_Building(const FF2Player player)
 	 *	4 = teleporter
  	 */
 
-	bool friendly = player.GetArgB(this_plugin_name, STUN_BUILDING_ABILITY, "friendly", m_ConVars.mp_friendlyfire.BoolValue);
+	bool friendly = player.GetArgB(this_plugin_name, STUN_BUILDING_ABILITY, "friendly", ConVars.mp_friendlyfire.BoolValue);
 
 	char full_clsname[64];
 
@@ -922,7 +922,7 @@ void Rage_CBS_Bow(const FF2Player player)
 
 	player.GetArgS(this_plugin_name, CBS_BOW_ABILITY, "attributes",  attributes, sizeof(attributes));
 	if( !attributes[0] ) {
-		attributes = m_ConVars.ff2_strangewep.BoolValue ?
+		attributes = ConVars.ff2_strangewep.BoolValue ?
 					 "6 ; 0.5 ; 37 ; 0.0 ; 214 ; 333 ; 280 ; 19":
 					 "6 ; 0.5 ; 37 ; 0.0 ; 280 ; 19";
 	}
@@ -1056,7 +1056,7 @@ void Rage_Matrix(const FF2Player player)
 	float duration = player.GetArgF(this_plugin_name, MATRIX_ABILITY, "duration", 1.0) + 1.0;
 
 	player.SetPropInt("bNotifySMAC_CVars", 1);
-	m_ConVars.host_timescale.FloatValue = 0.5;
+	ConVars.host_timescale.FloatValue = 0.5;
 
 	ma_data.timer = CreateTimer(duration * timescale, Timer_StopSlowMo, player, TIMER_FLAG_NO_MAPCHANGE);
 	UpdateCheatValue("1");
@@ -1076,8 +1076,8 @@ Action Timer_StopSlowMo(Handle timer, FF2Player player)
 
 	ma_data.InValidate();
 
-	float timescale = m_ConVars.host_timescale.FloatValue;
-	m_ConVars.host_timescale.FloatValue = 1.0;
+	float timescale = ConVars.host_timescale.FloatValue;
+	ConVars.host_timescale.FloatValue = 1.0;
 
 	UpdateCheatValue("0");
 
@@ -1293,14 +1293,14 @@ Action Timer_EquipModel(Handle timer, DataPack pack)
 void UpdateCheatValue(const char[] value)
 {
 	for( int client = MaxClients; client > 0; client-- ) {
-		if(IsClientInGame(client) && !IsFakeClient(client))
-			m_ConVars.sv_cheats.ReplicateToClient(client, value);
+		if( IsClientInGame(client) && !IsFakeClient(client) )
+			ConVars.sv_cheats.ReplicateToClient(client, value);
 	}
 }
 
 int SpawnManyObjects(const char[] classname, const int client, const char[] model, const int skin=0, const int amount=14, const float distance=30.0)
 {
-	if(!client || !IsClientInGame(client))
+	if( !client || !IsClientInGame(client) )
 		return;
 
 	static int m_iPackType = 0;
@@ -1441,7 +1441,7 @@ void HandleAttackerKill(FF2Player victim, FF2Player player)
 
 void HandleVictimKill(FF2Player player, int flags)
 {
-	if(	player.HasAbility(this_plugin_name, CLONE_ATK_ABILITY) && player.GetArgI(this_plugin_name, CLONE_ATK_ABILITY, "slay on death", 1) && !(flags & TF_DEATHFLAG_DEADRINGER)) {
+	if(	player.HasAbility(this_plugin_name, CLONE_ATK_ABILITY) && player.GetArgI(this_plugin_name, CLONE_ATK_ABILITY, "slay on death", 1) && !(flags & TF_DEATHFLAG_DEADRINGER) ) {
 		FF2Player iter;
 		int client = player.index;
 		for( int i = 1; i <= MaxClients; i++ ) {

--- a/addons/sourcemod/scripting/include/freak_fortress_2.inc
+++ b/addons/sourcemod/scripting/include/freak_fortress_2.inc
@@ -1387,31 +1387,41 @@ static void GetThisPluginName()
 {
 	char pluginName[80];
 	GetPluginFilename(INVALID_HANDLE, pluginName, sizeof(pluginName));
-	ReplaceString(pluginName, sizeof(pluginName), ".smx", "", false);
+	
+	/// make sure the file ends with ".ff2"
+	int extension_index = FindCharInString(plugin_buffer, '.', true);
+	if( extension_index == -1 || extension_index + 3 >= sizeof(pluginName) || plugin_buffer[extension_index+1] != 'f'|| plugin_buffer[extension_index+2] != 'f' || plugin_buffer[extension_index+3] != '2' ) {
+		return;
+	}
+
+	pluginName[extension_index+1] = 's';
+	pluginName[extension_index+2] = 'm';
+	pluginName[extension_index+3] = 'x';
+	
 	int forwardSlash = -1;
 	int backwardSlash = -1;
 	int finalPluginName = -1;
-	for(;;)
-	{
+	
+	for ( ;; ) {
 		forwardSlash = StrContains(pluginName[finalPluginName+1], "/");
 		backwardSlash = StrContains(pluginName[finalPluginName+1], "\\");
-		if((backwardSlash<forwardSlash && backwardSlash!=-1) || forwardSlash==-1)
-		{
-			if(backwardSlash == -1)
+		if( (backwardSlash<forwardSlash && backwardSlash!=-1) || forwardSlash==-1 ) {
+			if( backwardSlash == -1 )
 				break;
 
 			finalPluginName = backwardSlash;
 		}
-		else if((forwardSlash<backwardSlash && forwardSlash!=-1) || backwardSlash==-1)
-		{
+		else if( (forwardSlash<backwardSlash && forwardSlash!=-1) || backwardSlash==-1 ) {
 			if(forwardSlash == -1)
 				break;
 
 			finalPluginName = forwardSlash;
 		}
 	}
+	
 	strcopy(this_plugin_name, sizeof(this_plugin_name), pluginName[finalPluginName+1]);
 }
+
 
 public void OnPluginStart()
 {

--- a/addons/sourcemod/scripting/include/freak_fortress_2.inc
+++ b/addons/sourcemod/scripting/include/freak_fortress_2.inc
@@ -35,6 +35,10 @@ enum FF2RageType_t {
 #define FF2CallType_t   int
 #define FF2RageType_t	int
 
+#define RT_RAGE 0
+#define RT_WEIGHDOWN 1
+#define RT_CHARGE 2
+
 enum {
 	FF2FLAG_UBERREADY            = (1<<1),  /// Used when medic says "I'm charged!"				
 	FF2FLAG_ISBUFFED             = (1<<2),  /// Used when soldier uses the Battalion's Backup	
@@ -402,7 +406,8 @@ stock bool FF2_IsFF2Enabled()
  */
 stock void FF2_GetFF2Version(int version[3])
 {
-	FF2GameMode.PluginVersion(version);
+	if( FF2GameMode.IsOn() )
+		FF2GameMode.PluginVersion(version);
 }
 
 /**
@@ -416,7 +421,7 @@ stock void FF2_GetFF2Version(int version[3])
  */
 stock bool FF2_GetForkVersion(int fversion[3])
 {
-	FF2GameMode.ForkVersion(version);
+	return FF2GameMode.IsOn() && FF2GameMode.ForkVersion(version);
 }
 
 /**
@@ -428,7 +433,7 @@ stock bool FF2_GetForkVersion(int fversion[3])
  */
 stock int FF2_GetRoundState()
 {
-	return VSH2GameMode.GetPropInt("iRoundState");
+	return FF2GameMode.IsOn() && VSH2GameMode.GetPropInt("iRoundState");
 }
 
 /**
@@ -1382,7 +1387,7 @@ static void GetThisPluginName()
 {
 	char pluginName[80];
 	GetPluginFilename(INVALID_HANDLE, pluginName, sizeof(pluginName));
-	ReplaceString(pluginName, sizeof(pluginName), ".ff2", "", false);
+	ReplaceString(pluginName, sizeof(pluginName), ".smx", "", false);
 	int forwardSlash = -1;
 	int backwardSlash = -1;
 	int finalPluginName = -1;

--- a/addons/sourcemod/scripting/include/freak_fortress_2.inc
+++ b/addons/sourcemod/scripting/include/freak_fortress_2.inc
@@ -1388,15 +1388,13 @@ static void GetThisPluginName()
 	char pluginName[80];
 	GetPluginFilename(INVALID_HANDLE, pluginName, sizeof(pluginName));
 	
-	/// make sure the file ends with ".ff2"
+	/// make sure the file ends with ".smx"
 	int extension_index = FindCharInString(plugin_buffer, '.', true);
-	if( extension_index == -1 || extension_index + 3 >= sizeof(pluginName) || plugin_buffer[extension_index+1] != 'f'|| plugin_buffer[extension_index+2] != 'f' || plugin_buffer[extension_index+3] != '2' ) {
+	if( extension_index == -1 || extension_index + 3 >= sizeof(pluginName) || plugin_buffer[extension_index+1] != 's'|| plugin_buffer[extension_index+2] != 'm' || plugin_buffer[extension_index+3] != 'x' ) {
 		return;
 	}
 
-	pluginName[extension_index+1] = 's';
-	pluginName[extension_index+2] = 'm';
-	pluginName[extension_index+3] = 'x';
+	pluginName[extension_index] = 0;
 	
 	int forwardSlash = -1;
 	int backwardSlash = -1;

--- a/addons/sourcemod/scripting/modules/ff2/character.sp
+++ b/addons/sourcemod/scripting/modules/ff2/character.sp
@@ -84,9 +84,9 @@ static bool FF2_LoadCharacter(FF2Identity identity, char[] path)
 
 	/// ability* || Ability*
 	/**
-	 *	"Ability: Rage Test" {	//	Can be ability5965841, ability*, as long as the key was unique && less than 64 characters
+	 *	"Ability: Rage Test" {	///	Can be ability5965841, ability*, as long as the key was unique && less than 64 characters
 	 *		"name"			"thing"
-	 *		"plugin_name"	"pl_name"
+	 *		"plugin_name"	"pl_name"	///	"pl_name.smx"
 	 *	}
 	 */
 	{
@@ -99,7 +99,7 @@ static bool FF2_LoadCharacter(FF2Identity identity, char[] path)
 			if( !cur_ab || !cur_ab.Get("plugin_name", buffer, FF2_MAX_PLUGIN_NAME) )
 				continue;
 
-			BuildPath(Path_SM, path, PLATFORM_MAX_PATH, "plugins/freaks/%s.ff2", buffer);
+			BuildPath(Path_SM, path, PLATFORM_MAX_PATH, "plugins\\freaks\\%s.smx", buffer);
 			if( !FileExists(path) ) {
 				LogError("[VSH2/FF2] Character \"%s.cfg\" is missing \"%s\" subplugin!", identity.szName, path);
 			} else {
@@ -136,7 +136,7 @@ static bool FF2_LoadCharacter(FF2Identity identity, char[] path)
 
 	/// mat/mod download
 	/**
-	 *	"mat_download" {
+	 *	"mat_download" {	///	"mod_download"
 	 *		"<enum>"		"..."
 	 *		"<enum>"		"...."
 	 *		"<enum>"		".."

--- a/addons/sourcemod/scripting/modules/ff2/console.sp
+++ b/addons/sourcemod/scripting/modules/ff2/console.sp
@@ -6,16 +6,20 @@ void InitConVars()
 	CreateConVar("ff2_base_jumper_stun", "0", "Whether or not the Base Jumper should be disabled when a player gets stunned", _, true, 0.0, true, 1.0);
 	CreateConVar("ff2_solo_shame", "0", "Always insult the boss for solo raging", _, true, 0.0, true, 1.0);
 	
-	ff2.m_cvars.m_enabled 		= FindConVar("vsh2_enabled");
 	ff2.m_cvars.m_version 		= FindConVar("vsh2_version");
 	ff2.m_cvars.m_fljarate 		= FindConVar("vsh2_jarate_rage");
 	ff2.m_cvars.m_flairblast 	= FindConVar("vsh2_airblast_rage");
 	ff2.m_cvars.m_flmusicvol 	= FindConVar("vsh2_music_volume");
 	ff2.m_cvars.m_nextmap 		= FindConVar("sm_nextmap");
-	ff2.m_cvars.m_companion_min	= CreateConVar("ff2_companion_min", "4", "Minimum players required to enable duos", FCVAR_NOTIFY, .hasMin = true, .min = 1.0, .hasMax = true, .max = 34.0);
-	ff2.m_cvars.m_pack_name 	= CreateConVar("ff2_current", "Freak Fortress 2", "Freak Fortress 2 current boss pack name", FCVAR_NOTIFY);
-	ff2.m_cvars.m_pack_limit	= CreateConVar("ff2_pack_limit", "16", "Minimum players required to enable duos", FCVAR_NOTIFY, .hasMin = true, .min = 2.0);
-	ff2.m_cvars.m_pack_scramble	= CreateConVar("ff2_pack_scramble", "1", "Minimum players required to enable duos", FCVAR_NOTIFY);
+	
+	if( !ff2.m_cvars.m_companion_min )
+		ff2.m_cvars.m_companion_min	= CreateConVar("ff2_companion_min", "4", "Minimum players required to enable duos", FCVAR_NOTIFY, .hasMin = true, .min = 1.0, .hasMax = true, .max = 34.0);
+	if( !ff2.m_cvars.m_pack_name )
+		ff2.m_cvars.m_pack_name 	= CreateConVar("ff2_current", "Freak Fortress 2", "Freak Fortress 2 current boss pack name", FCVAR_NOTIFY);
+	if( !ff2.m_cvars.m_pack_limit )
+		ff2.m_cvars.m_pack_limit	= CreateConVar("ff2_pack_limit", "16", "Minimum players required to enable duos", FCVAR_NOTIFY, .hasMin = true, .min = 2.0);
+	if( !ff2.m_cvars.m_pack_scramble )
+		ff2.m_cvars.m_pack_scramble	= CreateConVar("ff2_pack_scramble", "1", "Minimum players required to enable duos", FCVAR_NOTIFY);
 	
 	ff2.m_cvars.m_nextmap.AddChangeHook(_OnNextMap);
 	

--- a/addons/sourcemod/scripting/modules/ff2/gamemode.sp
+++ b/addons/sourcemod/scripting/modules/ff2/gamemode.sp
@@ -1,3 +1,4 @@
+#include "modules/ff2/subplugins.sp"
 
 methodmap FF2GameMode < VSH2GameMode {
 	public static void HookToVSH2() {
@@ -24,6 +25,8 @@ methodmap FF2GameMode < VSH2GameMode {
 		}
 		
 		ff2.m_plugins = new FF2PluginList();
+		FF2PluginList.ForceUnloadAllSubPlugins();
+		FF2PluginList.FixSubPlugins();
 	}
 	
 	public static void LateLoadSubplugins() {
@@ -42,17 +45,18 @@ methodmap FF2GameMode < VSH2GameMode {
 		}
 	}
 	
-	public static void RemoveSubplugins(bool do_delete=false) {
-		if( ff2.m_plugins != null ) {
+	public static void RemoveSubPlugins(bool do_delete=false) {
+		if( !do_delete && ff2.m_plugins ) {
 			ff2.m_plugins.UnloadAllSubPlugins();
 		}
-		if( do_delete ) {
+		else if( ff2.m_plugins ) {
+			FF2PluginList.ForceUnloadAllSubPlugins();
 			delete ff2.m_plugins;
 		}
 	}
 	
 	public static void RemoveCfgMgr() {
-		if( ff2_cfgmgr != null ) {
+		if( ff2_cfgmgr ) {
 			ff2_cfgmgr.DeleteAll();
 		}
 		delete ff2_cfgmgr;

--- a/addons/sourcemod/scripting/modules/ff2/handler.sp
+++ b/addons/sourcemod/scripting/modules/ff2/handler.sp
@@ -27,7 +27,7 @@ void ProcessOnCallDownload()
 					for( int k = list.Length - 1; k >= 0; k-- ) {
 						list.At(k, snd_id);
 						if( snd_id.path[0] ) {
-							PrecacheSound(snd_id.path);
+							PrecacheSound(snd_id.path, true);
 						}
 					}
 				}
@@ -35,10 +35,13 @@ void ProcessOnCallDownload()
 			}
 			
 			/// Precache Models
-			if( (model_precache = identity.hCfg.GetSection("mod_precache")) ) {
+			model_precache = identity.hCfg.GetSection("character.mod_precache");
+			if( !model_precache )
+				model_precache = identity.hCfg.GetSection("character.mod_download");
+			if( model_precache ) {
 				for( int pos=model_precache.Size-1; pos >= 0; pos-- ) {
 					if( model_precache.GetIntKey(pos, model_path, sizeof(model_path)) && model_path[0] )
-						PrecacheModel(model_path);
+						PrecacheModel(model_path, true);
 				}
 			}
 		}

--- a/addons/sourcemod/scripting/modules/ff2/natives.sp
+++ b/addons/sourcemod/scripting/modules/ff2/natives.sp
@@ -300,22 +300,21 @@ any Native_FF2Player_PlayBGM(Handle plugin, int numParams)
 /** FF2GameMode methodmaps */
 int Native_FF2GameMode_IsOn(Handle plugin, int numParams)
 {
-	return( ff2.m_cvars.m_enabled.BoolValue );
+	return( ff2.m_vsh2 );
 }
 
 int Native_FF2GameMode_PluginVersion(Handle plugin, int numParams)
 {
 	char version_str[10];
 	ff2.m_cvars.m_version.GetString(version_str, sizeof(version_str));
-
+	
 	char digit[3][10];
 	int version_ints[3];
 	if( ExplodeString(version_str, ".", digit, sizeof(digit[]), sizeof(digit[][])) == 3 ) {
 		for( int i; i<3; i++ )
 			version_ints[i] = StringToInt(digit[i]);
 	}
-	SetNativeArray(1, version_ints, sizeof(version_ints));
-	return 1;
+	return SetNativeArray(1, version_ints, sizeof(version_ints)) == SP_ERROR_NONE;
 }
 
 int Native_FF2GameMode_ForkVersion(Handle plugin, int numParams)

--- a/addons/sourcemod/scripting/modules/ff2/subplugins.sp
+++ b/addons/sourcemod/scripting/modules/ff2/subplugins.sp
@@ -128,7 +128,7 @@ methodmap FF2PluginList < ArrayList {
 
 			/// make sure the file ends with ".ff2"
 			int extension_index = FindCharInString(plugin_buffer, '.', true);
-			if( extension_index == -1 || extension_index + 3 > PLATFORM_MAX_PATH || plugin_buffer[extension_index+1] != 'f'|| plugin_buffer[extension_index+2] != 'f' || plugin_buffer[extension_index+3] != '2' ) {
+			if( extension_index == -1 || extension_index > FF2_MAX_PLUGIN_NAME - 1 || plugin_buffer[extension_index+1] != 'f'|| plugin_buffer[extension_index+2] != 'f' || plugin_buffer[extension_index+3] != '2' || plugin_buffer[extension_index+4] != 0 ) {
 				continue;
 			}
 

--- a/addons/sourcemod/scripting/modules/ff2/utils.sp
+++ b/addons/sourcemod/scripting/modules/ff2/utils.sp
@@ -38,12 +38,9 @@ enum {
 
 enum { FF2_MAX_LIST_KEY = FF2_MAX_PLUGIN_NAME + FF2_MAX_ABILITY_NAME + 2 };		/// sizeof key in FF2AbilityList
 
-
 #include "modules/ff2/sound_list.sp"
-#include "modules/ff2/abilities.sp"
+#include "modules/ff2/character.sp"
 #include "modules/ff2/player.sp"
-#include "modules/ff2/subplugins.sp"
-
 
 stock FF2Player ZeroBossToFF2Player()
 {


### PR DESCRIPTION
#172.

Since @Pheubel and I did almost the same thing, my approach was to unload all plugins during load/unload to load only 
the needed plugins during an active round, well besides that some syntaxes fix and I've had problems with some subplugins that were using some natives like `FF2_GetRoundState` which call `VSH2GameMode.GetPropInt("iRoundState")` too early, now it's checking if vsh2 is already running before proceeding to do anything else.

Updated `GetThisPluginName`, changed extension name from '.ff2' to .'smx'.