### PR TITLE
Patch/failing to load ff2 subplugins

### DIFF
--- a/addons/sourcemod/scripting/freak_fortress_2.sp
+++ b/addons/sourcemod/scripting/freak_fortress_2.sp
@@ -93,6 +93,7 @@ public void OnLibraryAdded(const char[] name)
 		InitConVars();
 		ff2.m_vsh2 = true;
 		FF2GameMode.LoadFF2();
+		FF2GameMode.PrepareSubplugins();
 		FF2GameMode.LateLoadSubplugins();
 	}
 }

--- a/addons/sourcemod/scripting/include/freak_fortress_2.inc
+++ b/addons/sourcemod/scripting/include/freak_fortress_2.inc
@@ -1382,7 +1382,7 @@ static void GetThisPluginName()
 {
 	char pluginName[80];
 	GetPluginFilename(INVALID_HANDLE, pluginName, sizeof(pluginName));
-	ReplaceString(pluginName, sizeof(pluginName), ".ff2", "", false);
+	ReplaceString(pluginName, sizeof(pluginName), ".smx", "", false);
 	int forwardSlash = -1;
 	int backwardSlash = -1;
 	int finalPluginName = -1;

--- a/addons/sourcemod/scripting/modules/ff2/abilities.sp
+++ b/addons/sourcemod/scripting/modules/ff2/abilities.sp
@@ -99,7 +99,7 @@ static bool FF2_LoadCharacter(FF2Identity identity, char[] path)
 			if( !cur_ab || !cur_ab.Get("plugin_name", buffer, FF2_MAX_PLUGIN_NAME) )
 				continue;
 
-			BuildPath(Path_SM, path, PLATFORM_MAX_PATH, "plugins/freaks/%s.ff2", buffer);
+			BuildPath(Path_SM, path, PLATFORM_MAX_PATH, "plugins/freaks/%s.smx", buffer);
 			if( !FileExists(path) ) {
 				LogError("[VSH2/FF2] Character \"%s.cfg\" is missing \"%s\" subplugin!", identity.szName, path);
 			} else {

--- a/addons/sourcemod/scripting/modules/ff2/console.sp
+++ b/addons/sourcemod/scripting/modules/ff2/console.sp
@@ -145,8 +145,8 @@ static Action Load_Plugin(int client, int argc)
 	char pl_name[FF2_MAX_PLUGIN_NAME];
 	char path[PLATFORM_MAX_PATH];
 	GetCmdArgString(pl_name, sizeof(pl_name));
-	
-	BuildPath(Path_SM, path, sizeof(path), "plugins\\freaks\\%s.ff2", pl_name);
+
+	BuildPath(Path_SM, path, sizeof(path), "plugins\\freaks\\%s.smx", pl_name);
 	if( !FileExists(path) ) {
 		ReplyToCommand(client, "[VSH2/FF2] Plugin: \"%s\" doesn't exists", pl_name);
 		return Plugin_Handled;

--- a/addons/sourcemod/scripting/modules/ff2/subplugins.sp
+++ b/addons/sourcemod/scripting/modules/ff2/subplugins.sp
@@ -62,7 +62,7 @@ methodmap FF2PluginList < ArrayList {
 		if( this.IsFull )
 			return false;
 
-		ServerCommand("sm plugins load \"freaks\\%s.ff2\"", name);
+		ServerCommand("sm plugins load \"freaks\\%s.smx\"", name);
 
 		infos.loading = true;
 		strcopy(infos.name, sizeof(FF2SubPlugin::name), name);
@@ -100,7 +100,7 @@ methodmap FF2PluginList < ArrayList {
 		FF2SubPlugin info;
 		for( int i; i < this.Length; i++ ) {
 			this.GetInfo(i, info);
-			ServerCommand("sm plugins unload \"freaks\\%s.ff2\"", info.name);
+			ServerCommand("sm plugins unload \"freaks\\%s.smx\"", info.name);
 		}
 		this.Clear();
 	}
@@ -110,7 +110,7 @@ methodmap FF2PluginList < ArrayList {
 static Handle _FindPlugin(const char[] name)
 {
 	char pl_name[PLATFORM_MAX_PATH];
-	FormatEx(pl_name, sizeof(pl_name), "freaks\\%s.ff2", name);
+	FormatEx(pl_name, sizeof(pl_name), "freaks\\%s.smx", name);
 	Handle pl = FindPluginByFile(pl_name);
 	if( !pl || GetPluginStatus(pl)!=Plugin_Running ) {
 		LogError("[VSH2/FF2] Failed to load plugin: %s", pl_name);


### PR DESCRIPTION
This PR provides a solution to issue [#172 (Freak Fortress bridge broken due to stricter plugin loading)](https://github.com/VSH2-Devs/Vs-Saxton-Hale-2/issues/172)

It adds behavior to the startup to rename ff2 subplugins to have the smx extension and replaces occurrences that are expecting ".ff2".

After testing it seems to work, however i'm keeping this PR a draft for now to further investigate issues with loading ff2 ability plugins. although sourcemod seems to be happy to start loading the plugins now, it seems to run into issues with missing native functions.
![image](https://user-images.githubusercontent.com/22686676/121181904-cc028700-c862-11eb-8222-d4a80c52e814.png)
It could be that the server i am testing on is just not properly cleaned up, but i don't want to rule out other options yet.

It also seems to be complaining about missing properties.
![image](https://user-images.githubusercontent.com/22686676/121182456-64007080-c863-11eb-8ac5-da2b2a6d7ae8.png)

I am not sure yet what the best course of action for these issues is yet. i would love to hear from others what they think.
