### PR TITLE
Fixed Include Paths according to Issue #177

### DIFF
--- a/addons/sourcemod/scripting/modules/bosses.sp
+++ b/addons/sourcemod/scripting/modules/bosses.sp
@@ -3,15 +3,15 @@
  * After that, we add in the *forwards* for the core plugin to call.
  * After base player classes, we can include the gamemode class.
  */
-#include "modules/base.sp"
-#include "modules/forwards.sp"
-#include "modules/gamemode.sp"
+#include "base.sp"
+#include "forwards.sp"
+#include "gamemode.sp"
 
 /** --- DO NOT DELETE/MODIFY ANYTHING BEFORE THIS LINE --- */
 
-#include "modules/bosses/hale.sp"
-#include "modules/bosses/vagineer.sp"
-#include "modules/bosses/cbs.sp"
-#include "modules/bosses/hhh.sp"
-#include "modules/bosses/bunny.sp"
-//#include "modules/bosses/plague.sp"
+#include "bosses/hale.sp"
+#include "bosses/vagineer.sp"
+#include "bosses/cbs.sp"
+#include "bosses/hhh.sp"
+#include "bosses/bunny.sp"
+//#include "bosses/plague.sp"

--- a/addons/sourcemod/scripting/modules/handler.sp
+++ b/addons/sourcemod/scripting/modules/handler.sp
@@ -4,7 +4,7 @@
 
 #define MAXBOSS    (MaxDefaultVSH2Bosses + (g_modsys.m_hBossesRegistered.Length - 1))
 
-#include "modules/bosses.sp"
+#include "bosses.sp"
 
 /**
 	PLEASE REMEMBER THAT PLAYERS THAT DON'T HAVE THEIR BOSS ID'S SET ARE NOT ACTUAL BOSSES.


### PR DESCRIPTION
This PR addresses issue https://github.com/VSH2-Devs/Vs-Saxton-Hale-2/issues/177 (Current include behavior relies on bug in the compiler)
It changes the include paths to be in line with sourcemod 1.11 build 6708 (https://github.com/alliedmodders/sourcemod/pull/1518)