### PR TITLE
FF2 downloadfix

### DIFF
--- a/addons/sourcemod/scripting/modules/ff2/character.sp
+++ b/addons/sourcemod/scripting/modules/ff2/character.sp
@@ -161,7 +161,7 @@ bool FF2_LoadCharacter(FF2Identity identity, char[] path)
 
 		FF2Character_RegisterAbilities(this_char, identity.isNewAPI, identity.name, identity.abilityList);
 
-		FF2Character_ProcessDownloads(this_char, identity.isNewAPI, identity.name);
+		//FF2Character_ProcessDownloads(this_char, identity.isNewAPI, identity.name);
 
 		FF2Character_ProcessToSoundMap(this_char, identity.name, identity.soundMap);
 	}
@@ -383,7 +383,7 @@ static void FF2Character_RegisterAbilities(FF2Character this_char, bool new_api,
 	delete snap;
 }
 
-static void FF2Character_ProcessDownloads(FF2Character this_char, bool new_api, char[] boss_name)
+public void FF2Character_ProcessDownloads(FF2Character this_char, bool new_api, char[] boss_name)
 {
 	char path[PLATFORM_MAX_PATH], key_name[PLATFORM_MAX_PATH];
 	ConfigMap stacks;
@@ -455,6 +455,7 @@ static void FF2Character_ProcessDownloads(FF2Character this_char, bool new_api, 
 					FormatEx(key_name, sizeof(key_name), "%s%s", path, model_ext[j]);
 					if( FileExists(key_name, true) ) {
 						AddFileToDownloadsTable(key_name);
+						PrintToServer("AddModelDownload: %s", key_name);
 					} else if( StrContains(key_name, ".phy") == -1 ) {
 						LogError("[VSH2/FF2] Character \"%s.cfg\" is missing file \"%s\"!", boss_name, key_name);
 					}

--- a/addons/sourcemod/scripting/modules/ff2/character.sp
+++ b/addons/sourcemod/scripting/modules/ff2/character.sp
@@ -73,10 +73,10 @@ methodmap FF2AbilityList < ArrayList {
 			FF2Ability cur = this.Get(i);
 
 			cur.GetPlugin(buffer);
-			// Using !StrContains instead of !strcmp to allow old subplugins that were compiled as '.ff2' and have an extension-less 'this_plugin_name' 
+			// Using !StrContains instead of !strcmp to allow old subplugins that were compiled as '.ff2' and have an extension-less 'this_plugin_name'
 			if( !StrContains(plugin_name, buffer) ) {
 				cur.GetAbility(buffer);
-				if( !strcmp(buffer, ability_name) ) 
+				if( !strcmp(buffer, ability_name) )
 					return cur;
 			}
 		}
@@ -309,7 +309,7 @@ static void FF2Character_RegisterAbilities(FF2Character this_char, bool new_api,
 	 *	///	"ability1" spammed across every ability
 	 *	"ability1" {
 	 *		"name"		"rage_stunsg"
-	 *		"plugin_name"	"default_abilities" 
+	 *		"plugin_name"	"default_abilities"
 	 *
 	 *		"slot"		"0"	///	Batfoxkid's api
 	 *		/// "arg0"	"0"	///	default
@@ -455,7 +455,6 @@ public void FF2Character_ProcessDownloads(FF2Character this_char, bool new_api, 
 					FormatEx(key_name, sizeof(key_name), "%s%s", path, model_ext[j]);
 					if( FileExists(key_name, true) ) {
 						AddFileToDownloadsTable(key_name);
-						PrintToServer("AddModelDownload: %s", key_name);
 					} else if( StrContains(key_name, ".phy") == -1 ) {
 						LogError("[VSH2/FF2] Character \"%s.cfg\" is missing file \"%s\"!", boss_name, key_name);
 					}

--- a/addons/sourcemod/scripting/modules/ff2/character.sp
+++ b/addons/sourcemod/scripting/modules/ff2/character.sp
@@ -383,7 +383,7 @@ static void FF2Character_RegisterAbilities(FF2Character this_char, bool new_api,
 	delete snap;
 }
 
-public void FF2Character_ProcessDownloads(FF2Character this_char, bool new_api, char[] boss_name)
+void FF2Character_ProcessDownloads(FF2Character this_char, bool new_api, char[] boss_name)
 {
 	char path[PLATFORM_MAX_PATH], key_name[PLATFORM_MAX_PATH];
 	ConfigMap stacks;

--- a/addons/sourcemod/scripting/modules/ff2/handler.sp
+++ b/addons/sourcemod/scripting/modules/ff2/handler.sp
@@ -48,6 +48,9 @@ void ProcessOnCallDownload()
 					}
 				}
 			}
+
+			///Retry Downloads.
+			FF2Character_ProcessDownloads(cfg, new_api, identity.name);
 		}
 		delete snap;
 	}


### PR DESCRIPTION
Sourcemod cleans download table on map change. FF2 add files to download table before sourcemod cleans it. Therefore all the files from ff2 gets cleaned. 