### PR TITLE
Force ending the slowmo on round end.

### DIFF
--- a/addons/sourcemod/scripting/freaks/ff2_vsh2defaults.sp
+++ b/addons/sourcemod/scripting/freaks/ff2_vsh2defaults.sp
@@ -410,22 +410,7 @@ void _OnRoundEnd(const VSH2Player vsh2_player, bool bossBool, char message[MAXME
 	}
 
 	if ( ToFF2Player(vsh2_player).HasAbility(this_plugin_name, MATRIX_ABILITY) && ConVars.host_timescale.FloatValue != 1.0 )	{
-		int client = vsh2_player.index;
-
-		ma_data.InValidate();
-
-		float timescale = ConVars.host_timescale.FloatValue;
-		ConVars.host_timescale.FloatValue = 1.0;
-
-		UpdateCheatValue("0");
-
-		if( timescale != 1.0 )
-			EmitSoundToAll(SOUND_SLOW_MO_END, .updatePos = false);
-
-		if( client ) {
-			vsh2_player.SetPropInt("bNotifySMAC_CVars", 0);
-			SDKUnhook(client, SDKHook_PostThinkPost, Post_ClientSlowMoThink);
-		}
+		Timer_StopSlowMo(null, ToFF2Player(vsh2_player));
 	}
 }
 

--- a/addons/sourcemod/scripting/freaks/ff2_vsh2defaults.sp
+++ b/addons/sourcemod/scripting/freaks/ff2_vsh2defaults.sp
@@ -404,13 +404,15 @@ void _OnRoundEnd(const VSH2Player vsh2_player, bool bossBool, char message[MAXME
 		TriggerTimer(ma_data.timer);
 	}
 
-	if( ToFF2Player(vsh2_player).HasAbility(this_plugin_name, DEMOCHARGE_ABILITY) && democharge.bThinkHooked ) {
+	FF2Player ff2_player = ToFF2Player(vsh2_player);
+
+	if( ff2_player.HasAbility(this_plugin_name, DEMOCHARGE_ABILITY) && democharge.bThinkHooked ) {
 		VSH2_Unhook(OnBossThinkPost, _RunDemoChargeThink);
 		democharge.bThinkHooked = false;
 	}
 
-	if ( ToFF2Player(vsh2_player).HasAbility(this_plugin_name, MATRIX_ABILITY) && ConVars.host_timescale.FloatValue != 1.0 )	{
-		Timer_StopSlowMo(null, ToFF2Player(vsh2_player));
+	if ( ff2_player.HasAbility(this_plugin_name, MATRIX_ABILITY) && ConVars.host_timescale.FloatValue != 1.0 )	{
+		Timer_StopSlowMo(null, ff2_player);
 	}
 }
 

--- a/addons/sourcemod/scripting/freaks/ff2_vsh2defaults.sp
+++ b/addons/sourcemod/scripting/freaks/ff2_vsh2defaults.sp
@@ -408,6 +408,25 @@ void _OnRoundEnd(const VSH2Player vsh2_player, bool bossBool, char message[MAXME
 		VSH2_Unhook(OnBossThinkPost, _RunDemoChargeThink);
 		democharge.bThinkHooked = false;
 	}
+
+	if ( ToFF2Player(vsh2_player).HasAbility(this_plugin_name, MATRIX_ABILITY) && ConVars.host_timescale.FloatValue != 1.0 )	{
+		int client = vsh2_player.index;
+
+		ma_data.InValidate();
+
+		float timescale = ConVars.host_timescale.FloatValue;
+		ConVars.host_timescale.FloatValue = 1.0;
+
+		UpdateCheatValue("0");
+
+		if( timescale != 1.0 )
+			EmitSoundToAll(SOUND_SLOW_MO_END, .updatePos = false);
+
+		if( client ) {
+			vsh2_player.SetPropInt("bNotifySMAC_CVars", 0);
+			SDKUnhook(client, SDKHook_PostThinkPost, Post_ClientSlowMoThink);
+		}
+	}
 }
 
 void _RunDemoChargeThink(const VSH2Player vsh2_player)


### PR DESCRIPTION
It's been reported that if boss win during the slowmo the host_timescale will not be reset due to the subplugin has been unloaded. So before we unload the subplugin let's just reset it on round end to ensure the slowmo is over.