### PR TITLE
Update CI/CD to use sourcepawn 1.11

### DIFF
--- a/.github/workflows/Continuous Integration.yml
+++ b/.github/workflows/Continuous Integration.yml
@@ -14,16 +14,17 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build_linux:
-    name: (Linux) Compile SourcePawn ${{matrix.sm_version}}
+    name: (Linux) Compile SourcePawn ${{matrix.sm_version}} ${{ matrix.use_optional_dependencies && '(optionals enabled)' || '(optionals disabled)' 
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         # Set up Sourcemod versions to compile against
-        # sm_version: ['1.10', '1.11'] # TODO: uncomment when SM 1.11 becomes stable
-        sm_version: ['1.10']
+        sm_version: ['1.11']
         use_optional_dependencies: [false, true]
+        # TODO: uncomment when pipeline for backwards compatibility has been set up
+        # use_backwards_compatibility: [false, true]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/Continuous Integration.yml
+++ b/.github/workflows/Continuous Integration.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Fetch optional dependencies
         if: matrix.use_optional_dependencies
         run: |
-          wget https://raw.githubusercontent.com/FlaminSarge/tf2attributes/master/tf2attributes.inc -P addons/sourcemod/scripting/include
+          wget https://github.com/FlaminSarge/tf2attributes/releases/download/v1.7.3/tf2attributes.inc -P addons/sourcemod/scripting/include
           wget https://raw.githubusercontent.com/asherkin/SteamTools/master/plugin/steamtools.inc -P addons/sourcemod/scripting/include
           wget https://raw.githubusercontent.com/Flyflo/SM-Goomba-Stomp/master/addons/sourcemod/scripting/include/goomba.inc -P addons/sourcemod/scripting/include
           wget https://raw.githubusercontent.com/JoinedSenses/SourceMod-IncludeLibrary/master/include/updater.inc -P addons/sourcemod/scripting/include


### PR DESCRIPTION
Currently the CI/CD pipeline is failing due to use of features that are not available in 1.10. raising the minimum language requirement should help clear them up.