### PR TITLE
Bring back ff2's ragedamage to vsh2.

### DIFF
--- a/addons/sourcemod/scripting/freaks/vsh2ff2_sample.cfg
+++ b/addons/sourcemod/scripting/freaks/vsh2ff2_sample.cfg
@@ -15,6 +15,8 @@
 		"class"			"3"
 		"lives"
 
+		"damage_ratio"	""	//  default for 1.0, rage meter from damage will be scaled from this value.
+		"ragedamage"	""	//  dafault for 0.0 which follows vsh2's GiveRage api.
 		"ragedist"		""
 		"max lives"		""
 

--- a/addons/sourcemod/scripting/modules/ff2/player.sp
+++ b/addons/sourcemod/scripting/modules/ff2/player.sp
@@ -93,6 +93,15 @@ methodmap FF2Player < VSH2Player {
 		}
 	}
 
+	property float flRageDamage {
+		public get() {
+			return this.GetPropAny("flRageDamage");
+		}
+		public set(float val) {
+			this.SetPropAny("flRageDamage", val);
+		}
+	}
+
 	public void PlayBGM(const char[] music) {
 		this.PlayMusic(ff2.m_cvars.m_flmusicvol.FloatValue, music);
 	}

--- a/addons/sourcemod/scripting/modules/ff2/player.sp
+++ b/addons/sourcemod/scripting/modules/ff2/player.sp
@@ -86,19 +86,19 @@ methodmap FF2Player < VSH2Player {
 
 	property float flRageRatio {
 		public get() {
-			return this.GetPropAny("flRageRatio");
+			return this.GetPropFloat("flRageRatio");
 		}
 		public set(float val) {
-			this.SetPropAny("flRageRatio", val);
+			this.SetPropFloat("flRageRatio", val);
 		}
 	}
 
 	property float flRageDamage {
 		public get() {
-			return this.GetPropAny("flRageDamage");
+			return this.GetPropFloat("flRageDamage");
 		}
 		public set(float val) {
-			this.SetPropAny("flRageDamage", val);
+			this.SetPropFloat("flRageDamage", val);
 		}
 	}
 

--- a/addons/sourcemod/scripting/modules/ff2/vsh2_bridge.sp
+++ b/addons/sourcemod/scripting/modules/ff2/vsh2_bridge.sp
@@ -515,6 +515,9 @@ void OnBossInitializedFF2(const VSH2Player vsh2player)
 		if( !cfg.GetFloat("damage_ratio", val) )
 			val = 1.0;
 		player.flRageRatio = val;
+		if ( !cfg.GetFloat("ragedamage", val) )
+			val = 0.0;
+		player.flRageDamage = val;
 	}
 }
 
@@ -952,7 +955,11 @@ Action OnPlayerHurtFF2(Event event, const char[] name, bool dontBroadcast)
 	if( rage > 850.0 )
 		rage = 850.0;
 
-	player.GiveRage(RoundToCeil(rage));
+	if ( player.flRageDamage )
+		player.flRAGE += rage * 100.0 / player.flRageDamage;
+	else
+		player.GiveRage(RoundToCeil(rage));
+	
 	return Plugin_Continue;
 }
 
@@ -975,6 +982,7 @@ void OnVariablesResetFF2(const VSH2Player vsh2player)
 	player.bNoWeighdown = false;
 	player.bHideHUD = false;
 	player.flRageRatio = 1.0;
+	player.flRageDamage = 0.0;
 
 	player.SetPropAny("bNotifySMAC_CVars", false);
 	player.SetPropAny("bSupressRAGE", false);


### PR DESCRIPTION
Although not tested, the code should be running smoothly since it doesn't use `GiveRage` from vsh2.